### PR TITLE
Improve accessiblity for keyboard navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13041,6 +13041,11 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
+    },
     "follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@emotion/core": "^10.1.1",
     "@emotion/react": "^11.0.0",
+    "focus-visible": "^5.2.0",
     "framer-motion": "^2.9.4",
     "gatsby": "^2.26.1",
     "gatsby-image": "^2.5.0",

--- a/src/client/components/atoms/BaseButton/index.tsx
+++ b/src/client/components/atoms/BaseButton/index.tsx
@@ -39,10 +39,6 @@ export const BaseButton = React.forwardRef<BaseButtonRef, BaseButtonProps>(
           transition: background-color 0.3s ease-out;
           background: none;
 
-          &:focus {
-            outline: auto;
-          }
-
           @media (hover: hover) and (pointer: fine) {
             &:hover {
               background-color: ${theme.colors.theme[backgroundType][

--- a/src/client/components/atoms/BaseButton/index.tsx
+++ b/src/client/components/atoms/BaseButton/index.tsx
@@ -15,42 +15,47 @@ export type BaseButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   verticalPadding?: SpacingKey;
 };
 
-export const BaseButton: React.FC<BaseButtonProps> = props => {
-  const {
-    backgroundType = 'background',
-    horizontalPadding = 'xxs',
-    verticalPadding = 'xxs',
-    backgroundColorVariant = 'variant0',
-    children,
-    ...buttonProps
-  } = props;
+export type BaseButtonRef = HTMLButtonElement;
 
-  const theme = useAppTheme();
+export const BaseButton = React.forwardRef<BaseButtonRef, BaseButtonProps>(
+  (props, ref) => {
+    const {
+      backgroundType = 'background',
+      horizontalPadding = 'xxs',
+      verticalPadding = 'xxs',
+      backgroundColorVariant = 'variant0',
+      children,
+      ...buttonProps
+    } = props;
 
-  return (
-    <button
-      css={css`
-        padding: ${commonStyles.spacing[verticalPadding]}
-          ${commonStyles.spacing[horizontalPadding]};
-        border-radius: ${commonStyles.borderRadius.xs};
-        transition: background-color 0.3s ease-out;
-        background: none;
+    const theme = useAppTheme();
 
-        &:focus {
-          outline: auto;
-        }
+    return (
+      <button
+        css={css`
+          padding: ${commonStyles.spacing[verticalPadding]}
+            ${commonStyles.spacing[horizontalPadding]};
+          border-radius: ${commonStyles.borderRadius.xs};
+          transition: background-color 0.3s ease-out;
+          background: none;
 
-        @media (hover: hover) and (pointer: fine) {
-          &:hover {
-            background-color: ${theme.colors.theme[backgroundType][
-              backgroundColorVariant
-            ]};
+          &:focus {
+            outline: auto;
           }
-        }
-      `}
-      {...buttonProps}
-    >
-      {children}
-    </button>
-  );
-};
+
+          @media (hover: hover) and (pointer: fine) {
+            &:hover {
+              background-color: ${theme.colors.theme[backgroundType][
+                backgroundColorVariant
+              ]};
+            }
+          }
+        `}
+        {...buttonProps}
+        ref={ref}
+      >
+        {children}
+      </button>
+    );
+  }
+);

--- a/src/client/components/atoms/BaseLink/index.tsx
+++ b/src/client/components/atoms/BaseLink/index.tsx
@@ -8,18 +8,18 @@ export type BaseLinkProps = {
 } & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export const BaseLink: React.FC<BaseLinkProps> = props => {
-  const { to, disabled, className, onClick, children } = props;
+  const { to, disabled, className, onClick, children, ...anchorProps } = props;
 
   const isAbsoluteLink = isAbsoluteUrl(to);
 
   return disabled ? (
     <div css={className}>{children}</div>
   ) : isAbsoluteLink ? (
-    <a href={to} css={className} onClick={onClick}>
+    <a href={to} css={className} onClick={onClick} {...anchorProps}>
       {children}
     </a>
   ) : (
-    <Link to={to} css={className} onClick={onClick}>
+    <Link to={to} css={className} onClick={onClick} {...anchorProps}>
       {children}
     </Link>
   );

--- a/src/client/components/atoms/BaseLink/index.tsx
+++ b/src/client/components/atoms/BaseLink/index.tsx
@@ -7,20 +7,30 @@ export type BaseLinkProps = {
   disabled?: boolean;
 } & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
-export const BaseLink: React.FC<BaseLinkProps> = props => {
-  const { to, disabled, className, onClick, children, ...anchorProps } = props;
+export type BaseLinkRef = HTMLAnchorElement;
 
-  const isAbsoluteLink = isAbsoluteUrl(to);
+export const BaseLink = React.forwardRef<BaseLinkRef, BaseLinkProps>(
+  (props, ref) => {
+    const { to, disabled, css, onClick, children, ...anchorProps } = props;
 
-  return disabled ? (
-    <div css={className}>{children}</div>
-  ) : isAbsoluteLink ? (
-    <a href={to} css={className} onClick={onClick} {...anchorProps}>
-      {children}
-    </a>
-  ) : (
-    <Link to={to} css={className} onClick={onClick} {...anchorProps}>
-      {children}
-    </Link>
-  );
-};
+    const isAbsoluteLink = isAbsoluteUrl(to);
+
+    return disabled ? (
+      <div css={css}>{children}</div>
+    ) : isAbsoluteLink ? (
+      <a href={to} css={css} onClick={onClick} {...anchorProps} ref={ref}>
+        {children}
+      </a>
+    ) : (
+      <Link
+        to={to}
+        css={css}
+        onClick={onClick}
+        {...anchorProps}
+        ref={ref as any}
+      >
+        {children}
+      </Link>
+    );
+  }
+);

--- a/src/client/components/atoms/Surface/index.tsx
+++ b/src/client/components/atoms/Surface/index.tsx
@@ -70,10 +70,6 @@ export const Surface: React.FC<SurfaceProps> = props => {
             ].boxShadow};
           }
         }
-
-        &:focus {
-          outline: auto;
-        }
       `,
       overlay: css`
         @media (hover: hover) and (pointer: fine) {

--- a/src/client/components/molecules/links/TextLink/index.tsx
+++ b/src/client/components/molecules/links/TextLink/index.tsx
@@ -5,7 +5,11 @@ import {
   Typography,
   TypographyProps,
 } from 'client/components/atoms/Typography';
-import { BaseLink, BaseLinkProps } from 'client/components/atoms/BaseLink';
+import {
+  BaseLink,
+  BaseLinkProps,
+  BaseLinkRef,
+} from 'client/components/atoms/BaseLink';
 import { useAppTheme, commonStyles } from 'client/styles/tokens';
 import {
   mapBackgroundToForeground,
@@ -22,82 +26,87 @@ export type TextLinkProps = BaseLinkProps &
     backgroundColorVariant?: ThemeColorKey;
   };
 
-export const TextLink: React.FC<TextLinkProps> = props => {
-  const {
-    to,
-    typographyVariant = 'body1',
-    showUnderline = true,
-    textColor = { on: 'onBackground', variant: 'standard' },
-    backgroundType = 'background',
-    backgroundColorVariant = 'variant0',
-    underlineColorVariant = 'variant0',
-    children,
-    disabled = false,
-    tabIndex,
-    onClick,
-    ...typographyProps
-  } = props;
+export type TextLinkRef = BaseLinkRef;
 
-  const theme = useAppTheme();
+export const TextLink = React.forwardRef<TextLinkRef, TextLinkProps>(
+  (props, ref) => {
+    const {
+      to,
+      typographyVariant = 'body1',
+      showUnderline = true,
+      textColor = { on: 'onBackground', variant: 'standard' },
+      backgroundType = 'background',
+      backgroundColorVariant = 'variant0',
+      underlineColorVariant = 'variant0',
+      children,
+      disabled = false,
+      tabIndex,
+      onClick,
+      ...typographyProps
+    } = props;
 
-  const baseStyles = React.useMemo(
-    () => css`
-      display: inline-block;
-      padding: ${commonStyles.spacing.xxs} ${commonStyles.spacing.xs};
-      border-radius: ${commonStyles.borderRadius.xs};
-      background: none;
-    `,
-    []
-  );
+    const theme = useAppTheme();
 
-  const styles = React.useMemo(
-    () =>
-      disabled
-        ? baseStyles
-        : css`
-            ${baseStyles};
-            transition: background-color 0.3s ease-out;
-            text-decoration: ${showUnderline ? 'underline' : 'none'};
-            text-underline-position: under;
-            text-decoration-color: ${theme.colors.theme[
-              mapBackgroundToForeground(backgroundType)
-            ][underlineColorVariant]};
+    const baseStyles = React.useMemo(
+      () => css`
+        display: inline-block;
+        padding: ${commonStyles.spacing.xxs} ${commonStyles.spacing.xs};
+        border-radius: ${commonStyles.borderRadius.xs};
+        background: none;
+      `,
+      []
+    );
 
-            @media (hover: hover) and (pointer: fine) {
-              &:hover {
-                background-color: ${theme.colors.theme[backgroundType][
-                  backgroundColorVariant
-                ]};
+    const styles = React.useMemo(
+      () =>
+        disabled
+          ? baseStyles
+          : css`
+              ${baseStyles};
+              transition: background-color 0.3s ease-out;
+              text-decoration: ${showUnderline ? 'underline' : 'none'};
+              text-underline-position: under;
+              text-decoration-color: ${theme.colors.theme[
+                mapBackgroundToForeground(backgroundType)
+              ][underlineColorVariant]};
+
+              @media (hover: hover) and (pointer: fine) {
+                &:hover {
+                  background-color: ${theme.colors.theme[backgroundType][
+                    backgroundColorVariant
+                  ]};
+                }
               }
-            }
-          `,
-    [
-      disabled,
-      baseStyles,
-      backgroundColorVariant,
-      backgroundType,
-      showUnderline,
-      theme.colors.theme,
-      underlineColorVariant,
-    ]
-  );
+            `,
+      [
+        disabled,
+        baseStyles,
+        backgroundColorVariant,
+        backgroundType,
+        showUnderline,
+        theme.colors.theme,
+        underlineColorVariant,
+      ]
+    );
 
-  return (
-    <BaseLink
-      to={to}
-      onClick={onClick}
-      disabled={disabled}
-      css={styles}
-      tabIndex={tabIndex}
-    >
-      <Typography
-        variant={typographyVariant}
-        textColor={textColor}
-        element="span"
-        {...typographyProps}
+    return (
+      <BaseLink
+        to={to}
+        onClick={onClick}
+        disabled={disabled}
+        css={styles}
+        tabIndex={tabIndex}
+        ref={ref}
       >
-        {children}
-      </Typography>
-    </BaseLink>
-  );
-};
+        <Typography
+          variant={typographyVariant}
+          textColor={textColor}
+          element="span"
+          {...typographyProps}
+        >
+          {children}
+        </Typography>
+      </BaseLink>
+    );
+  }
+);

--- a/src/client/components/molecules/links/TextLink/index.tsx
+++ b/src/client/components/molecules/links/TextLink/index.tsx
@@ -62,10 +62,6 @@ export const TextLink: React.FC<TextLinkProps> = props => {
               mapBackgroundToForeground(backgroundType)
             ][underlineColorVariant]};
 
-            &:focus {
-              outline: auto;
-            }
-
             @media (hover: hover) and (pointer: fine) {
               &:hover {
                 background-color: ${theme.colors.theme[backgroundType][

--- a/src/client/components/molecules/links/TextLink/index.tsx
+++ b/src/client/components/molecules/links/TextLink/index.tsx
@@ -33,6 +33,7 @@ export const TextLink: React.FC<TextLinkProps> = props => {
     underlineColorVariant = 'variant0',
     children,
     disabled = false,
+    tabIndex,
     onClick,
     ...typographyProps
   } = props;
@@ -82,7 +83,13 @@ export const TextLink: React.FC<TextLinkProps> = props => {
   );
 
   return (
-    <BaseLink to={to} onClick={onClick} disabled={disabled} css={styles}>
+    <BaseLink
+      to={to}
+      onClick={onClick}
+      disabled={disabled}
+      css={styles}
+      tabIndex={tabIndex}
+    >
       <Typography
         variant={typographyVariant}
         textColor={textColor}

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -120,6 +120,20 @@ const Settings: React.FC = () => {
     setLanguage('zh');
   }, [setLanguage]);
 
+  const handleEscape = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      toggleDropdown(false);
+    }
+  };
+
+  React.useEffect(() => {
+    if (isDropdownOpen) {
+      document.addEventListener('keyup', handleEscape);
+    } else {
+      document.removeEventListener('keyup', handleEscape);
+    }
+  }, [isDropdownOpen]);
+
   return (
     <div
       ref={componentRef}

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -22,6 +22,8 @@ import { TextLink } from 'client/components/molecules/links/TextLink';
 import { BaseButton, BaseButtonRef } from 'client/components/atoms/BaseButton';
 import { useTranslations } from 'client/hooks/useTranslations';
 
+const settingDropdownId = 'setting-dropdown';
+
 const SettingHeading: React.FC = props => (
   <Typography
     variant="body2"
@@ -95,6 +97,7 @@ const Settings: React.FC = () => {
   );
   const componentRef = React.useRef<HTMLDivElement>(null);
   useOnClickOutside(componentRef, hideDropdown);
+  const firstItemRef = React.useRef<HTMLButtonElement>(null);
 
   const theme = useAppTheme();
   const { themeMode, language, setTheme, setLanguage } = useAppContext();
@@ -133,6 +136,7 @@ const Settings: React.FC = () => {
 
   React.useEffect(() => {
     if (isDropdownOpen) {
+      firstItemRef.current?.focus();
       document.addEventListener('keyup', handleEscape);
     } else {
       document.removeEventListener('keyup', handleEscape);
@@ -151,7 +155,7 @@ const Settings: React.FC = () => {
       <BaseButton
         onClick={switchDropdown}
         aria-label={getTranslation('settings')}
-        aria-controls="setting-dropdown"
+        aria-controls={settingDropdownId}
         aria-haspopup
       >
         <SettingsIcon fill={theme.colors.theme.onSurface.standard} />
@@ -173,7 +177,7 @@ const Settings: React.FC = () => {
               top: calc(${commonStyles.sizes.navigationBarHeight} - 8px);
               min-width: 140px;
             `}
-            id="setting-dropdown"
+            id={settingDropdownId}
           >
             <Card elevation={componentElevationKey.dropdown} borderRadius="s">
               <SettingHeading>{getTranslation('languages')}</SettingHeading>
@@ -185,6 +189,7 @@ const Settings: React.FC = () => {
                 <SelectionItem
                   isSelected={language === 'en'}
                   onClick={handleClickEnglish}
+                  ref={firstItemRef}
                 >
                   English
                 </SelectionItem>

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -176,7 +176,6 @@ const Settings: React.FC = () => {
           open: { scale: 1, opacity: 1 },
           closed: { scale: 0, opacity: 0 },
         }}
-        exit={{ scale: 0, opacity: 0 }}
         transition={{ duration: 0.2 }}
         css={css`
           position: absolute;

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -23,6 +23,7 @@ import { BaseButton, BaseButtonRef } from 'client/components/atoms/BaseButton';
 import { useTranslations } from 'client/hooks/useTranslations';
 
 const settingDropdownId = 'setting-dropdown';
+const settingItemClass = 'setting-item';
 
 const SettingHeading: React.FC = props => (
   <Typography
@@ -49,7 +50,7 @@ const SelectionItem = React.forwardRef<SelectionItemRef, SelectionItemProps>(
     const { onClick, isSelected, children, ...buttonProps } = props;
 
     return (
-      <li>
+      <li className={settingItemClass}>
         <BaseButton
           onClick={onClick}
           disabled={isSelected}
@@ -97,7 +98,7 @@ const Settings: React.FC = () => {
   );
   const componentRef = React.useRef<HTMLDivElement>(null);
   useOnClickOutside(componentRef, hideDropdown);
-  const firstItemRef = React.useRef<HTMLButtonElement>(null);
+  const languageListRef = React.useRef<HTMLUListElement>(null);
 
   const theme = useAppTheme();
   const { themeMode, language, setTheme, setLanguage } = useAppContext();
@@ -136,7 +137,11 @@ const Settings: React.FC = () => {
 
   React.useEffect(() => {
     if (isDropdownOpen) {
-      firstItemRef.current?.focus();
+      const firstSelectableItem = languageListRef.current?.querySelector(
+        `.${settingItemClass} > button:not([disabled])`
+      ) as HTMLButtonElement | null;
+      firstSelectableItem?.focus();
+
       document.addEventListener('keyup', handleEscape);
     } else {
       document.removeEventListener('keyup', handleEscape);
@@ -185,11 +190,11 @@ const Settings: React.FC = () => {
                 css={css`
                   margin-top: ${commonStyles.spacing.xs};
                 `}
+                ref={languageListRef}
               >
                 <SelectionItem
                   isSelected={language === 'en'}
                   onClick={handleClickEnglish}
-                  ref={firstItemRef}
                 >
                   English
                 </SelectionItem>

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -80,13 +80,13 @@ const SelectionItem: React.FC<
 };
 
 const Settings: React.FC = () => {
-  const [isDropdownVisible, toggleDropdown] = React.useState(false);
+  const [isDropdownOpen, toggleDropdown] = React.useState(false);
   const hideDropdown = React.useCallback(() => toggleDropdown(false), [
     toggleDropdown,
   ]);
   const switchDropdown = React.useCallback(
-    () => toggleDropdown(!isDropdownVisible),
-    [isDropdownVisible, toggleDropdown]
+    () => toggleDropdown(!isDropdownOpen),
+    [isDropdownOpen, toggleDropdown]
   );
   const componentRef = React.useRef<HTMLDivElement>(null);
   useOnClickOutside(componentRef, hideDropdown);
@@ -132,15 +132,17 @@ const Settings: React.FC = () => {
       <BaseButton
         onClick={switchDropdown}
         aria-label={getTranslation('settings')}
+        aria-controls="setting-dropdown"
+        aria-haspopup
       >
         <SettingsIcon fill={theme.colors.theme.onSurface.standard} />
       </BaseButton>
       <AnimatePresence>
-        {isDropdownVisible && (
+        {isDropdownOpen && (
           <motion.div
             initial={{ scale: 0, opacity: 0 }}
             style={{ originX: 1, originY: 0 }}
-            animate={isDropdownVisible ? 'open' : 'closed'}
+            animate={isDropdownOpen ? 'open' : 'closed'}
             variants={{
               open: { scale: 1, opacity: 1 },
               closed: { scale: 0, opacity: 0 },
@@ -152,6 +154,7 @@ const Settings: React.FC = () => {
               top: calc(${commonStyles.sizes.navigationBarHeight} - 8px);
               min-width: 140px;
             `}
+            id="setting-dropdown"
           >
             <Card elevation={componentElevationKey.dropdown} borderRadius="s">
               <SettingHeading>{getTranslation('languages')}</SettingHeading>

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -21,6 +21,7 @@ import { Divider } from 'client/components/atoms/Divider';
 import { TextLink } from 'client/components/molecules/links/TextLink';
 import { BaseButton, BaseButtonRef } from 'client/components/atoms/BaseButton';
 import { useTranslations } from 'client/hooks/useTranslations';
+import { MENU_BUTTON_ID } from 'client/constants/ids';
 
 const settingDropdownId = 'setting-dropdown';
 const settingItemClass = 'setting-item';
@@ -349,6 +350,8 @@ export const NavigationBar: React.FC<{
               <BaseButton
                 className="small"
                 aria-label={getTranslation('menu')}
+                aria-controls={MENU_BUTTON_ID}
+                aria-haspopup
                 onClick={props.onOpenSidebar}
                 css={css`
                   margin-left: ${commonStyles.spacing.xxs};

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -99,6 +99,7 @@ const Settings: React.FC = () => {
   const componentRef = React.useRef<HTMLDivElement>(null);
   useOnClickOutside(componentRef, hideDropdown);
   const languageListRef = React.useRef<HTMLUListElement>(null);
+  const settingsButtonRef = React.useRef<BaseButtonRef>(null);
 
   const theme = useAppTheme();
   const { themeMode, language, setTheme, setLanguage } = useAppContext();
@@ -129,13 +130,14 @@ const Settings: React.FC = () => {
     setLanguage('zh');
   }, [setLanguage]);
 
-  const handleEscape = (event: KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      toggleDropdown(false);
-    }
-  };
-
   React.useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        toggleDropdown(false);
+        settingsButtonRef.current?.focus();
+      }
+    };
+
     if (isDropdownOpen) {
       const firstSelectableItem = languageListRef.current?.querySelector(
         `.${settingItemClass} > button:not([disabled])`
@@ -162,6 +164,7 @@ const Settings: React.FC = () => {
         aria-label={getTranslation('settings')}
         aria-controls={settingDropdownId}
         aria-haspopup
+        ref={settingsButtonRef}
       >
         <SettingsIcon fill={theme.colors.theme.onSurface.standard} />
       </BaseButton>

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -256,6 +256,7 @@ const Settings: React.FC = () => {
 
 export const NavigationBar: React.FC<{
   onOpenSidebar: () => void;
+  menuButtonRef?: React.RefObject<BaseButtonRef>;
 }> = props => {
   const theme = useAppTheme();
   const { getTranslation } = useTranslations();
@@ -352,6 +353,7 @@ export const NavigationBar: React.FC<{
                 css={css`
                   margin-left: ${commonStyles.spacing.xxs};
                 `}
+                ref={props.menuButtonRef}
               >
                 <MenuIcon fill={theme.colors.theme.onSurface.standard} />
               </BaseButton>

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -1,7 +1,7 @@
 /**@jsx jsx */
 import { jsx, css } from '@emotion/core';
 import * as React from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { Card } from 'client/components/atoms/Card';
 import { MenuIcon } from 'client/components/atoms/icons/MenuIcon';
 import { RadioCheckIcon } from 'client/components/atoms/icons/RadioCheckIcon';
@@ -165,87 +165,89 @@ const Settings: React.FC = () => {
       >
         <SettingsIcon fill={theme.colors.theme.onSurface.standard} />
       </BaseButton>
-      <AnimatePresence>
-        {isDropdownOpen && (
-          <motion.div
-            initial={{ scale: 0, opacity: 0 }}
-            style={{ originX: 1, originY: 0 }}
-            animate={isDropdownOpen ? 'open' : 'closed'}
-            variants={{
-              open: { scale: 1, opacity: 1 },
-              closed: { scale: 0, opacity: 0 },
-            }}
-            exit={{ scale: 0, opacity: 0 }}
-            transition={{ duration: 0.2 }}
+      <motion.div
+        initial={{ scale: 0, opacity: 0 }}
+        style={{ originX: 1, originY: 0 }}
+        animate={isDropdownOpen ? 'open' : 'closed'}
+        variants={{
+          open: { scale: 1, opacity: 1 },
+          closed: { scale: 0, opacity: 0 },
+        }}
+        exit={{ scale: 0, opacity: 0 }}
+        transition={{ duration: 0.2 }}
+        css={css`
+          position: absolute;
+          top: calc(${commonStyles.sizes.navigationBarHeight} - 8px);
+          min-width: 140px;
+        `}
+        id={settingDropdownId}
+      >
+        <Card elevation={componentElevationKey.dropdown} borderRadius="s">
+          <SettingHeading>{getTranslation('languages')}</SettingHeading>
+          <ul
             css={css`
-              position: absolute;
-              top: calc(${commonStyles.sizes.navigationBarHeight} - 8px);
-              min-width: 140px;
+              margin-top: ${commonStyles.spacing.xs};
             `}
-            id={settingDropdownId}
+            ref={languageListRef}
           >
-            <Card elevation={componentElevationKey.dropdown} borderRadius="s">
-              <SettingHeading>{getTranslation('languages')}</SettingHeading>
-              <ul
-                css={css`
-                  margin-top: ${commonStyles.spacing.xs};
-                `}
-                ref={languageListRef}
-              >
-                <SelectionItem
-                  isSelected={language === 'en'}
-                  onClick={handleClickEnglish}
-                >
-                  English
-                </SelectionItem>
-                <SelectionItem
-                  isSelected={language === 'ja'}
-                  onClick={handleClickJapanese}
-                >
-                  日本語
-                </SelectionItem>
-                <SelectionItem
-                  isSelected={language === 'zh'}
-                  onClick={handleClickChinese}
-                >
-                  简体中文
-                </SelectionItem>
-              </ul>
-              <Divider
-                lineColor={{ on: 'onSurface', variant: 'variant1' }}
-                css={css`
-                  margin: ${commonStyles.spacing.s} 0;
-                `}
-              />
-              <SettingHeading>{getTranslation('color theme')}</SettingHeading>
-              <ul
-                css={css`
-                  margin-top: ${commonStyles.spacing.xs};
-                `}
-              >
-                <SelectionItem
-                  isSelected={themeMode === 'dark'}
-                  onClick={handleClickDarkTheme}
-                >
-                  {getTranslation('dark')}
-                </SelectionItem>
-                <SelectionItem
-                  isSelected={themeMode === 'light'}
-                  onClick={handleClickLightTheme}
-                >
-                  {getTranslation('light')}
-                </SelectionItem>
-                <SelectionItem
-                  isSelected={themeMode === 'auto'}
-                  onClick={handleClickAutoTheme}
-                >
-                  {getTranslation('auto')}
-                </SelectionItem>
-              </ul>
-            </Card>
-          </motion.div>
-        )}
-      </AnimatePresence>
+            <SelectionItem
+              isSelected={language === 'en'}
+              tabIndex={isDropdownOpen ? 0 : -1}
+              onClick={handleClickEnglish}
+            >
+              English
+            </SelectionItem>
+            <SelectionItem
+              isSelected={language === 'ja'}
+              tabIndex={isDropdownOpen ? 0 : -1}
+              onClick={handleClickJapanese}
+            >
+              日本語
+            </SelectionItem>
+            <SelectionItem
+              isSelected={language === 'zh'}
+              tabIndex={isDropdownOpen ? 0 : -1}
+              onClick={handleClickChinese}
+            >
+              简体中文
+            </SelectionItem>
+          </ul>
+          <Divider
+            lineColor={{ on: 'onSurface', variant: 'variant1' }}
+            css={css`
+              margin: ${commonStyles.spacing.s} 0;
+            `}
+          />
+          <SettingHeading>{getTranslation('color theme')}</SettingHeading>
+          <ul
+            css={css`
+              margin-top: ${commonStyles.spacing.xs};
+            `}
+          >
+            <SelectionItem
+              isSelected={themeMode === 'dark'}
+              tabIndex={isDropdownOpen ? 0 : -1}
+              onClick={handleClickDarkTheme}
+            >
+              {getTranslation('dark')}
+            </SelectionItem>
+            <SelectionItem
+              isSelected={themeMode === 'light'}
+              tabIndex={isDropdownOpen ? 0 : -1}
+              onClick={handleClickLightTheme}
+            >
+              {getTranslation('light')}
+            </SelectionItem>
+            <SelectionItem
+              isSelected={themeMode === 'auto'}
+              tabIndex={isDropdownOpen ? 0 : -1}
+              onClick={handleClickAutoTheme}
+            >
+              {getTranslation('auto')}
+            </SelectionItem>
+          </ul>
+        </Card>
+      </motion.div>
     </div>
   );
 };

--- a/src/client/components/templates/Page/components/NavigationBar/index.tsx
+++ b/src/client/components/templates/Page/components/NavigationBar/index.tsx
@@ -19,7 +19,7 @@ import {
 } from 'client/utils/urls';
 import { Divider } from 'client/components/atoms/Divider';
 import { TextLink } from 'client/components/molecules/links/TextLink';
-import { BaseButton } from 'client/components/atoms/BaseButton';
+import { BaseButton, BaseButtonRef } from 'client/components/atoms/BaseButton';
 import { useTranslations } from 'client/hooks/useTranslations';
 
 const SettingHeading: React.FC = props => (
@@ -36,48 +36,53 @@ const SettingHeading: React.FC = props => (
   </Typography>
 );
 
-const SelectionItem: React.FC<
-  {
-    isSelected: boolean;
-  } & React.ButtonHTMLAttributes<HTMLButtonElement>
-> = props => {
-  const { onClick, isSelected, children, ...buttonProps } = props;
+type SelectionItemProps = {
+  isSelected: boolean;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
 
-  return (
-    <li>
-      <BaseButton
-        onClick={onClick}
-        disabled={isSelected}
-        css={css`
-          display: flex;
-          align-items: center;
-          width: 100%;
-        `}
-        {...buttonProps}
-      >
-        <RadioCheckIcon
-          isChecked={isSelected}
-          unCheckColor="variant0"
-          checkColor="purple1"
-          width={20}
-          height={20}
-        />
-        <Typography
-          variant="body3"
-          element="span"
+type SelectionItemRef = BaseButtonRef;
+
+const SelectionItem = React.forwardRef<SelectionItemRef, SelectionItemProps>(
+  (props, ref) => {
+    const { onClick, isSelected, children, ...buttonProps } = props;
+
+    return (
+      <li>
+        <BaseButton
+          onClick={onClick}
+          disabled={isSelected}
           css={css`
-            line-height: 24px;
-            height: 24px;
-            margin-left: ${commonStyles.spacing.xs};
-            text-transform: capitalize;
+            display: flex;
+            align-items: center;
+            width: 100%;
           `}
+          {...buttonProps}
+          ref={ref}
         >
-          {children}
-        </Typography>
-      </BaseButton>
-    </li>
-  );
-};
+          <RadioCheckIcon
+            isChecked={isSelected}
+            unCheckColor="variant0"
+            checkColor="purple1"
+            width={20}
+            height={20}
+          />
+          <Typography
+            variant="body3"
+            element="span"
+            css={css`
+              line-height: 24px;
+              height: 24px;
+              margin-left: ${commonStyles.spacing.xs};
+              text-transform: capitalize;
+            `}
+          >
+            {children}
+          </Typography>
+        </BaseButton>
+      </li>
+    );
+  }
+);
 
 const Settings: React.FC = () => {
   const [isDropdownOpen, toggleDropdown] = React.useState(false);

--- a/src/client/components/templates/Page/components/Sidebar/index.tsx
+++ b/src/client/components/templates/Page/components/Sidebar/index.tsx
@@ -10,7 +10,7 @@ import {
   getSearchUrl,
 } from 'client/utils/urls';
 import { componentElevationKey } from 'client/styles/tokens/elevation';
-import { BaseButton } from 'client/components/atoms/BaseButton';
+import { BaseButton, BaseButtonRef } from 'client/components/atoms/BaseButton';
 import {
   TextLink,
   TextLinkProps,
@@ -82,6 +82,7 @@ export type SidebarProps = {
   open: boolean;
   onClose: () => void;
   className?: string;
+  menuButtonRef?: React.RefObject<BaseButtonRef>;
 };
 
 export const Sidebar: React.FC<SidebarProps> = props => {
@@ -94,6 +95,7 @@ export const Sidebar: React.FC<SidebarProps> = props => {
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         onClose();
+        props.menuButtonRef?.current?.focus();
       }
     };
 
@@ -104,7 +106,7 @@ export const Sidebar: React.FC<SidebarProps> = props => {
     } else {
       document.removeEventListener('keyup', handleEscape);
     }
-  }, [open, onClose]);
+  }, [open, onClose, props.menuButtonRef]);
 
   return (
     <div className={props.className}>

--- a/src/client/components/templates/Page/components/Sidebar/index.tsx
+++ b/src/client/components/templates/Page/components/Sidebar/index.tsx
@@ -1,7 +1,7 @@
 /**@jsx jsx */
 import { jsx, css } from '@emotion/core';
 import * as React from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { CloseIcon } from 'client/components/atoms/icons/CloseIcon';
 import { useAppTheme } from 'client/styles/tokens';
 import {
@@ -68,126 +68,114 @@ export const Sidebar: React.FC<SidebarProps> = props => {
 
   return (
     <div className={props.className}>
-      <AnimatePresence>
-        {open && (
-          <React.Fragment>
-            <motion.div
-              initial={{ opacity: 0 }}
-              exit={{ opacity: 0 }}
-              animate={open ? 'open' : 'closed'}
-              variants={{
-                open: { opacity: 1 },
-                closed: { opacity: 0 },
-              }}
-              transition={transition}
-              css={css`
-                background-color: rgba(65, 65, 65, 0.8);
-                height: 100vh;
-                opacity: 0;
-                pointer-events: none;
-                position: fixed;
-                width: 100vw;
-                z-index: ${theme.elevation[componentElevationKey.sidebar]
-                  .zIndex};
-              `}
-            />
-            <motion.div
-              initial={{ x: '-102vw' }}
-              exit={{ x: '-102vw' }}
-              animate={open ? 'open' : 'closed'}
-              variants={{
-                open: { x: '0' },
-                closed: { x: '-102vw' },
-              }}
-              transition={transition}
-              onClick={onClose}
-              css={css`
-                height: 100vh;
-                position: fixed;
-                width: 100vw;
-                z-index: ${theme.elevation[componentElevationKey.sidebar]
-                  .zIndex};
-              `}
-            />
-            <motion.nav
-              initial={{ x: '-102vw' }}
-              exit={{ x: '-102vw' }}
-              animate={open ? 'open' : 'closed'}
-              variants={{
-                open: { x: '0' },
-                closed: { x: '-102vw' },
-              }}
-              transition={transition}
-              css={css`
-                background-color: ${theme.colors.theme.secondary.variant0};
-                box-shadow: ${theme.elevation[componentElevationKey.sidebar]
-                  .boxShadow};
-                z-index: ${theme.elevation[componentElevationKey.sidebar]
-                  .zIndex};
-                width: 70vw;
-                height: 100vh;
-                max-width: 400px;
-                top: 0;
-                left: 0;
-                padding-top: env(safe-area-inset-top);
-                position: fixed;
-                overflow: hidden;
-                transform: translateX(-102vw);
-              `}
-            >
-              <BaseButton
-                aria-label="close"
-                onClick={onClose}
-                backgroundType="primary"
-                backgroundColorVariant="standard"
-                css={css`
-                  margin: ${theme.spacing.m};
-                `}
-              >
-                <CloseIcon fill={theme.colors.theme.onSecondary.standard} />
-              </BaseButton>
-              <div
-                css={css`
-                  text-align: center;
-                  margin: ${theme.spacing.l} auto;
-                `}
-              >
-                <ul>
-                  <NavigationItem to={getDiscographyUrl()} onClick={onClose}>
-                    {getTranslation('discography')}
-                  </NavigationItem>
-                  <NavigationItem to={getMembersUrl()} onClick={onClose}>
-                    {getTranslation('members')}
-                  </NavigationItem>
-                  <NavigationItem to={getSearchUrl()} onClick={onClose}>
-                    {getTranslation('search')}
-                  </NavigationItem>
-                </ul>
-              </div>
-              <Divider
-                lineColor={{ on: 'onSecondary', variant: 'standard' }}
-                css={css`
-                  margin-top: 2em;
-                  width: 40px;
-                `}
-              />
-              <div
-                css={css`
-                  text-align: center;
-                  margin-top: 2em;
-                `}
-              >
-                <SidebarItem
-                  to="https://github.com/shawnrivers/nogilib"
-                  onClick={onClose}
-                >
-                  {getTranslation('about')}
-                </SidebarItem>
-              </div>
-            </motion.nav>
-          </React.Fragment>
-        )}
-      </AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={open ? 'open' : 'closed'}
+        variants={{
+          open: { opacity: 1 },
+          closed: { opacity: 0 },
+        }}
+        transition={transition}
+        css={css`
+          background-color: rgba(65, 65, 65, 0.8);
+          height: 100vh;
+          opacity: 0;
+          pointer-events: none;
+          position: fixed;
+          width: 100vw;
+          z-index: ${theme.elevation[componentElevationKey.sidebar].zIndex};
+        `}
+      />
+      <motion.div
+        initial={{ x: '-102vw' }}
+        animate={open ? 'open' : 'closed'}
+        variants={{
+          open: { x: '0' },
+          closed: { x: '-102vw' },
+        }}
+        transition={transition}
+        onClick={onClose}
+        css={css`
+          height: 100vh;
+          position: fixed;
+          width: 100vw;
+          z-index: ${theme.elevation[componentElevationKey.sidebar].zIndex};
+        `}
+      />
+      <motion.nav
+        initial={{ x: '-102vw' }}
+        animate={open ? 'open' : 'closed'}
+        variants={{
+          open: { x: '0' },
+          closed: { x: '-102vw' },
+        }}
+        transition={transition}
+        css={css`
+          background-color: ${theme.colors.theme.secondary.variant0};
+          box-shadow: ${theme.elevation[componentElevationKey.sidebar]
+            .boxShadow};
+          z-index: ${theme.elevation[componentElevationKey.sidebar].zIndex};
+          width: 70vw;
+          height: 100vh;
+          max-width: 400px;
+          top: 0;
+          left: 0;
+          padding-top: env(safe-area-inset-top);
+          position: fixed;
+          overflow: hidden;
+          transform: translateX(-102vw);
+        `}
+      >
+        <BaseButton
+          aria-label="close"
+          onClick={onClose}
+          backgroundType="primary"
+          backgroundColorVariant="standard"
+          css={css`
+            margin: ${theme.spacing.m};
+          `}
+        >
+          <CloseIcon fill={theme.colors.theme.onSecondary.standard} />
+        </BaseButton>
+        <div
+          css={css`
+            text-align: center;
+            margin: ${theme.spacing.l} auto;
+          `}
+        >
+          <ul>
+            <NavigationItem to={getDiscographyUrl()} onClick={onClose}>
+              {getTranslation('discography')}
+            </NavigationItem>
+            <NavigationItem to={getMembersUrl()} onClick={onClose}>
+              {getTranslation('members')}
+            </NavigationItem>
+            <NavigationItem to={getSearchUrl()} onClick={onClose}>
+              {getTranslation('search')}
+            </NavigationItem>
+          </ul>
+        </div>
+        <Divider
+          lineColor={{ on: 'onSecondary', variant: 'standard' }}
+          css={css`
+            margin-top: 2em;
+            width: 40px;
+          `}
+        />
+        <div
+          css={css`
+            text-align: center;
+            margin-top: 2em;
+          `}
+        >
+          <SidebarItem
+            to="https://github.com/shawnrivers/nogilib"
+            onClick={onClose}
+          >
+            {getTranslation('about')}
+          </SidebarItem>
+        </div>
+      </motion.nav>
     </div>
   );
 };

--- a/src/client/components/templates/Page/components/Sidebar/index.tsx
+++ b/src/client/components/templates/Page/components/Sidebar/index.tsx
@@ -14,6 +14,7 @@ import { BaseButton } from 'client/components/atoms/BaseButton';
 import {
   TextLink,
   TextLinkProps,
+  TextLinkRef,
 } from 'client/components/molecules/links/TextLink';
 import { useTranslations } from 'client/hooks/useTranslations';
 import { Divider } from 'client/components/atoms/Divider';
@@ -27,41 +28,53 @@ type SidebarItemProps = Omit<
   | 'showUnderline'
 >;
 
-const SidebarItem: React.FC<SidebarItemProps> = props => {
-  const { to, children, onClick, ...restProps } = props;
+type SidebarItemRef = TextLinkRef;
 
-  return (
-    <TextLink
-      to={to}
-      typographyVariant="h6"
-      textColor={{ on: 'onSecondary', variant: 'standard' }}
-      backgroundType="primary"
-      backgroundColorVariant="standard"
-      showUnderline={false}
-      onClick={onClick}
-      css={css`
-        text-transform: uppercase;
-      `}
-      {...restProps}
-    >
-      {children}
-    </TextLink>
-  );
-};
+const SidebarItem = React.forwardRef<SidebarItemRef, SidebarItemProps>(
+  (props, ref) => {
+    const { to, children, onClick, ...restProps } = props;
 
-const NavigationItem: React.FC<Omit<SidebarItemProps, 'element'>> = props => {
-  const { children, ...sidebarItemProps } = props;
+    return (
+      <TextLink
+        to={to}
+        typographyVariant="h6"
+        textColor={{ on: 'onSecondary', variant: 'standard' }}
+        backgroundType="primary"
+        backgroundColorVariant="standard"
+        showUnderline={false}
+        onClick={onClick}
+        css={css`
+          text-transform: uppercase;
+        `}
+        {...restProps}
+        ref={ref}
+      >
+        {children}
+      </TextLink>
+    );
+  }
+);
 
-  return (
-    <li
-      css={css`
-        margin-top: 1em;
-      `}
-    >
-      <SidebarItem {...sidebarItemProps}>{children}</SidebarItem>
-    </li>
-  );
-};
+type NavigationItemProps = Omit<SidebarItemProps, 'element'>;
+type NavigationItemRef = SidebarItemRef;
+
+const NavigationItem = React.forwardRef<NavigationItemRef, NavigationItemProps>(
+  (props, ref) => {
+    const { children, ...sidebarItemProps } = props;
+
+    return (
+      <li
+        css={css`
+          margin-top: 1em;
+        `}
+      >
+        <SidebarItem {...sidebarItemProps} ref={ref}>
+          {children}
+        </SidebarItem>
+      </li>
+    );
+  }
+);
 
 const transition = { duration: 0.2 };
 

--- a/src/client/components/templates/Page/components/Sidebar/index.tsx
+++ b/src/client/components/templates/Page/components/Sidebar/index.tsx
@@ -89,6 +89,13 @@ export const Sidebar: React.FC<SidebarProps> = props => {
   const { getTranslation } = useTranslations();
   const { open, onClose } = props;
 
+  const firstNavigationItemLink = React.useRef<NavigationItemRef>(null);
+  React.useEffect(() => {
+    if (open) {
+      firstNavigationItemLink.current?.focus();
+    }
+  }, [open]);
+
   return (
     <div className={props.className}>
       <motion.div
@@ -172,6 +179,7 @@ export const Sidebar: React.FC<SidebarProps> = props => {
               to={getDiscographyUrl()}
               tabIndex={open ? 0 : -1}
               onClick={onClose}
+              ref={firstNavigationItemLink}
             >
               {getTranslation('discography')}
             </NavigationItem>

--- a/src/client/components/templates/Page/components/Sidebar/index.tsx
+++ b/src/client/components/templates/Page/components/Sidebar/index.tsx
@@ -81,21 +81,20 @@ const transition = { duration: 0.2 };
 export type SidebarProps = {
   open: boolean;
   onClose: () => void;
-  className?: string;
   menuButtonRef?: React.RefObject<BaseButtonRef>;
-};
+} & React.HTMLAttributes<HTMLElement>;
 
 export const Sidebar: React.FC<SidebarProps> = props => {
   const theme = useAppTheme();
   const { getTranslation } = useTranslations();
-  const { open, onClose } = props;
+  const { open, menuButtonRef, onClose, ...restProps } = props;
 
   const firstNavigationItemLink = React.useRef<NavigationItemRef>(null);
   React.useEffect(() => {
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         onClose();
-        props.menuButtonRef?.current?.focus();
+        menuButtonRef?.current?.focus();
       }
     };
 
@@ -106,10 +105,10 @@ export const Sidebar: React.FC<SidebarProps> = props => {
     } else {
       document.removeEventListener('keyup', handleEscape);
     }
-  }, [open, onClose, props.menuButtonRef]);
+  }, [open, onClose, menuButtonRef]);
 
   return (
-    <div className={props.className}>
+    <div {...restProps}>
       <motion.div
         initial={{ opacity: 0 }}
         animate={open ? 'open' : 'closed'}

--- a/src/client/components/templates/Page/components/Sidebar/index.tsx
+++ b/src/client/components/templates/Page/components/Sidebar/index.tsx
@@ -91,10 +91,20 @@ export const Sidebar: React.FC<SidebarProps> = props => {
 
   const firstNavigationItemLink = React.useRef<NavigationItemRef>(null);
   React.useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
     if (open) {
       firstNavigationItemLink.current?.focus();
+
+      document.addEventListener('keyup', handleEscape);
+    } else {
+      document.removeEventListener('keyup', handleEscape);
     }
-  }, [open]);
+  }, [open, onClose]);
 
   return (
     <div className={props.className}>

--- a/src/client/components/templates/Page/components/Sidebar/index.tsx
+++ b/src/client/components/templates/Page/components/Sidebar/index.tsx
@@ -18,27 +18,39 @@ import {
 import { useTranslations } from 'client/hooks/useTranslations';
 import { Divider } from 'client/components/atoms/Divider';
 
-type SidebarItemProps = Pick<TextLinkProps, 'to' | 'onClick'>;
+type SidebarItemProps = Omit<
+  TextLinkProps,
+  | 'typographyVariant'
+  | 'textColor'
+  | 'backgroundType'
+  | 'backgroundColorVariant'
+  | 'showUnderline'
+>;
 
-const SidebarItem: React.FC<SidebarItemProps> = props => (
-  <TextLink
-    to={props.to}
-    typographyVariant="h6"
-    textColor={{ on: 'onSecondary', variant: 'standard' }}
-    backgroundType="primary"
-    backgroundColorVariant="standard"
-    showUnderline={false}
-    onClick={props.onClick}
-    css={css`
-      text-transform: uppercase;
-    `}
-  >
-    {props.children}
-  </TextLink>
-);
+const SidebarItem: React.FC<SidebarItemProps> = props => {
+  const { to, children, onClick, ...restProps } = props;
+
+  return (
+    <TextLink
+      to={to}
+      typographyVariant="h6"
+      textColor={{ on: 'onSecondary', variant: 'standard' }}
+      backgroundType="primary"
+      backgroundColorVariant="standard"
+      showUnderline={false}
+      onClick={onClick}
+      css={css`
+        text-transform: uppercase;
+      `}
+      {...restProps}
+    >
+      {children}
+    </TextLink>
+  );
+};
 
 const NavigationItem: React.FC<Omit<SidebarItemProps, 'element'>> = props => {
-  const { to, children, onClick } = props;
+  const { children, ...sidebarItemProps } = props;
 
   return (
     <li
@@ -46,9 +58,7 @@ const NavigationItem: React.FC<Omit<SidebarItemProps, 'element'>> = props => {
         margin-top: 1em;
       `}
     >
-      <SidebarItem to={to} onClick={onClick}>
-        {children}
-      </SidebarItem>
+      <SidebarItem {...sidebarItemProps}>{children}</SidebarItem>
     </li>
   );
 };
@@ -131,6 +141,7 @@ export const Sidebar: React.FC<SidebarProps> = props => {
           onClick={onClose}
           backgroundType="primary"
           backgroundColorVariant="standard"
+          tabIndex={open ? 0 : -1}
           css={css`
             margin: ${theme.spacing.m};
           `}

--- a/src/client/components/templates/Page/components/Sidebar/index.tsx
+++ b/src/client/components/templates/Page/components/Sidebar/index.tsx
@@ -155,13 +155,25 @@ export const Sidebar: React.FC<SidebarProps> = props => {
           `}
         >
           <ul>
-            <NavigationItem to={getDiscographyUrl()} onClick={onClose}>
+            <NavigationItem
+              to={getDiscographyUrl()}
+              tabIndex={open ? 0 : -1}
+              onClick={onClose}
+            >
               {getTranslation('discography')}
             </NavigationItem>
-            <NavigationItem to={getMembersUrl()} onClick={onClose}>
+            <NavigationItem
+              to={getMembersUrl()}
+              tabIndex={open ? 0 : -1}
+              onClick={onClose}
+            >
               {getTranslation('members')}
             </NavigationItem>
-            <NavigationItem to={getSearchUrl()} onClick={onClose}>
+            <NavigationItem
+              to={getSearchUrl()}
+              tabIndex={open ? 0 : -1}
+              onClick={onClose}
+            >
               {getTranslation('search')}
             </NavigationItem>
           </ul>
@@ -181,6 +193,7 @@ export const Sidebar: React.FC<SidebarProps> = props => {
         >
           <SidebarItem
             to="https://github.com/shawnrivers/nogilib"
+            tabIndex={open ? 0 : -1}
             onClick={onClose}
           >
             {getTranslation('about')}

--- a/src/client/components/templates/Page/index.tsx
+++ b/src/client/components/templates/Page/index.tsx
@@ -8,6 +8,7 @@ import {
 import { NavigationBar } from 'client/components/templates/Page/components/NavigationBar';
 import { Sidebar } from 'client/components/templates/Page/components/Sidebar';
 import { commonStyles, useAppTheme } from 'client/styles/tokens';
+import { BaseButtonRef } from 'client/components/atoms/BaseButton';
 
 export const PageContent: React.FC<HeaderProps> = props => {
   return (
@@ -49,6 +50,8 @@ export const Page: React.FC = props => {
     toggleSidebar(false);
   }, [toggleSidebar]);
 
+  const menuButtonRef = React.useRef<BaseButtonRef>(null);
+
   return (
     <div
       css={css`
@@ -74,11 +77,15 @@ export const Page: React.FC = props => {
         }
       `}
     >
-      <NavigationBar onOpenSidebar={handleOpenSidebar} />
+      <NavigationBar
+        onOpenSidebar={handleOpenSidebar}
+        menuButtonRef={menuButtonRef}
+      />
       <Sidebar
         open={isSidebarOpen}
         onClose={handleCloseSidebar}
         className="small"
+        menuButtonRef={menuButtonRef}
       />
       {props.children}
     </div>

--- a/src/client/components/templates/Page/index.tsx
+++ b/src/client/components/templates/Page/index.tsx
@@ -9,6 +9,7 @@ import { NavigationBar } from 'client/components/templates/Page/components/Navig
 import { Sidebar } from 'client/components/templates/Page/components/Sidebar';
 import { commonStyles, useAppTheme } from 'client/styles/tokens';
 import { BaseButtonRef } from 'client/components/atoms/BaseButton';
+import { MENU_BUTTON_ID } from 'client/constants/ids';
 
 export const PageContent: React.FC<HeaderProps> = props => {
   return (
@@ -86,6 +87,7 @@ export const Page: React.FC = props => {
         onClose={handleCloseSidebar}
         className="small"
         menuButtonRef={menuButtonRef}
+        id={MENU_BUTTON_ID}
       />
       {props.children}
     </div>

--- a/src/client/constants/ids.ts
+++ b/src/client/constants/ids.ts
@@ -1,0 +1,1 @@
+export const MENU_BUTTON_ID = 'menu-button';

--- a/src/client/features/Search/template.tsx
+++ b/src/client/features/Search/template.tsx
@@ -87,7 +87,7 @@ export const Search: React.FC<SearchProps> = props => {
                   color: ${theme.colors.theme.onBackground.variant1};
                 }
 
-                &:focus {
+                &.focus-visible {
                   border-color: ${theme.colors.theme.onBackground.standard};
                 }
               `}

--- a/src/client/store/theme/context.tsx
+++ b/src/client/store/theme/context.tsx
@@ -6,6 +6,7 @@ import { themes } from 'client/styles/tokens';
 import { useDarkModeMediaQuery } from 'client/hooks/useDarkModeMediaQuery';
 import { useAppContext } from 'client/hooks/useAppContext';
 import { useLocalStorageForContext } from 'client/hooks/useLocalStorageForContext';
+import 'focus-visible';
 
 export const ThemeProvider: React.FC = props => {
   const { themeKey } = useAppContext();
@@ -70,6 +71,14 @@ export const ThemeProvider: React.FC = props => {
             vertical-align: middle;
             white-space: normal;
             background: none;
+          }
+
+          .js-focus-visible :focus:not(.focus-visible) {
+            outline: none;
+          }
+
+          .focus-visible {
+            outline: auto;
           }
         `}
       />

--- a/src/client/store/theme/context.tsx
+++ b/src/client/store/theme/context.tsx
@@ -44,6 +44,11 @@ export const ThemeProvider: React.FC = props => {
           a {
             color: inherit;
             text-decoration: inherit;
+            outline: inherit;
+
+            :focus {
+              outline-offset: 0;
+            }
           }
 
           ul,


### PR DESCRIPTION
## Changes

- When the dropdown is open, you can now press the `Escape` key to close the dropdown
- When the dropdown is open, the focus will automatically move to the first selectable item 

## TODO

- [x] Only show an outline while using keyboard navigation
- [x] Hide dropdown component but not remove it from the DOM
- [x] Apply the same improvements to navigation sidebar
