### PR TITLE
Fix home page image layout shift

### DIFF
--- a/src/client/components/atoms/images/DynamicImage/index.tsx
+++ b/src/client/components/atoms/images/DynamicImage/index.tsx
@@ -2,11 +2,14 @@ import Img from 'gatsby-image';
 import React from 'react';
 import { useAllImagesContext } from 'client/store/images/useAllImagesContext';
 
-export type GatsbyImageProps = {
+export type DynamicImageProps = {
   src: string;
 } & Omit<React.ComponentProps<typeof Img>, 'fluid'>;
 
-export const GatsbyImage: React.FC<GatsbyImageProps> = ({ src, ...props }) => {
+export const DynamicImage: React.FC<DynamicImageProps> = ({
+  src,
+  ...props
+}) => {
   const { imgStyle, ...restProps } = props;
   const { allImages } = useAllImagesContext();
 

--- a/src/client/components/atoms/images/GirdImage/index.tsx
+++ b/src/client/components/atoms/images/GirdImage/index.tsx
@@ -3,13 +3,13 @@ import { css, jsx } from '@emotion/core';
 import * as React from 'react';
 import { componentElevationKey } from 'client/styles/tokens/elevation';
 import {
-  GatsbyImage,
-  GatsbyImageProps,
-} from 'client/components/atoms/images/GatsbyImage';
+  DynamicImage,
+  DynamicImageProps,
+} from 'client/components/atoms/images/DynamicImage';
 import { commonStyles, useAppTheme } from 'client/styles/tokens';
 import { BorderRadiusKey } from 'client/styles/tokens/borderRadius';
 
-type ImageProps = GatsbyImageProps & {
+type ImageProps = DynamicImageProps & {
   borderRadius: BorderRadiusKey;
   shadow: boolean;
 };
@@ -42,7 +42,7 @@ const Image: React.FC<ImageProps> = props => {
           position: absolute;
         `}
       >
-        <GatsbyImage
+        <DynamicImage
           src={src}
           alt={alt}
           css={css`

--- a/src/client/components/atoms/images/StaticImage/index.tsx
+++ b/src/client/components/atoms/images/StaticImage/index.tsx
@@ -1,0 +1,18 @@
+import Img from 'gatsby-image';
+import React from 'react';
+
+export const StaticImage: React.FC<
+  React.ComponentProps<typeof Img>
+> = props => {
+  const { imgStyle, ...restProps } = props;
+
+  return (
+    <Img
+      imgStyle={{
+        transition: 'none',
+        ...imgStyle,
+      }}
+      {...restProps}
+    />
+  );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,9 @@
 /**@jsx jsx */
 import { jsx, css } from '@emotion/core';
 import * as React from 'react';
+import { graphql, useStaticQuery } from 'gatsby';
 import { PageContent } from 'client/components/templates/Page';
 import { Typography } from 'client/components/atoms/Typography';
-import { GatsbyImage } from 'client/components/atoms/images/GatsbyImage';
 import { commonStyles, useAppTheme } from 'client/styles/tokens';
 import {
   getDiscographyUrl,
@@ -16,6 +16,7 @@ import { Card } from 'client/components/atoms/Card';
 import { DiscographyIcon } from 'client/components/atoms/icons/DiscographyIcon';
 import { MembersIcon } from 'client/components/atoms/icons/MembersIcon';
 import { SearchIcon } from 'client/components/atoms/icons/SearchIcon';
+import { StaticImage } from 'client/components/atoms/images/StaticImage';
 
 const SubHeading: React.FC = props => (
   <Typography
@@ -49,6 +50,17 @@ const SectionTextLink: React.FC<{
 const HomePage: React.FC = () => {
   const { getTranslation } = useTranslations();
   const theme = useAppTheme();
+  const heroImageData = useStaticQuery(graphql`
+    query {
+      file(relativePath: { eq: "design/preview.jpg" }) {
+        childImageSharp {
+          fixed(width: 800, height: 400) {
+            ...GatsbyImageSharpFixed_withWebp
+          }
+        }
+      }
+    }
+  `);
 
   return (
     <PageContent>
@@ -60,13 +72,11 @@ const HomePage: React.FC = () => {
           margin-top: ${commonStyles.spacing.l};
         `}
       >
-        <GatsbyImage
-          src="design/preview.jpg"
+        <StaticImage
+          fixed={heroImageData.file.childImageSharp.fixed}
           alt="NOGILIB"
           css={css`
-            width: 800px;
             max-width: 80vw;
-            height: 400px;
             border-radius: ${commonStyles.borderRadius.m};
             box-shadow: ${commonStyles.elevations[3].boxShadow};
           `}


### PR DESCRIPTION
## Changes

- Rename `GatsbyImage` component as `DynamicImage`
- Add `StaticImage` component
- Use a fixed-sized image component on the home page
