### PR TITLE
Reduce image size

### DIFF
--- a/src/client/components/atoms/images/GatsbyImage/index.tsx
+++ b/src/client/components/atoms/images/GatsbyImage/index.tsx
@@ -1,9 +1,7 @@
 import Img, { GatsbyImageProps } from 'gatsby-image';
 import React from 'react';
 
-export type StaticImageProps = GatsbyImageProps;
-
-export const StaticImage: React.FC<StaticImageProps> = props => {
+export const GatsbyImage: React.FC<GatsbyImageProps> = props => {
   const { imgStyle, ...restProps } = props;
 
   return (

--- a/src/client/components/atoms/images/GirdImage/index.tsx
+++ b/src/client/components/atoms/images/GirdImage/index.tsx
@@ -1,70 +1,12 @@
 /**@jsx jsx */
 import { css, jsx } from '@emotion/core';
 import * as React from 'react';
-import { FluidObject } from 'gatsby-image';
 import { componentElevationKey } from 'client/styles/tokens/elevation';
 import { commonStyles, useAppTheme } from 'client/styles/tokens';
 import { BorderRadiusKey } from 'client/styles/tokens/borderRadius';
-import {
-  StaticImage,
-  StaticImageProps,
-} from 'client/components/atoms/images/StaticImage';
+import { GatsbyImage } from 'client/components/atoms/images/GatsbyImage';
 
-type ImageProps = {
-  fluid: FluidObject;
-  borderRadius: BorderRadiusKey;
-  shadow: boolean;
-} & StaticImageProps;
-
-const Image: React.FC<ImageProps> = props => {
-  const { fluid, borderRadius, shadow, imgStyle, ...staticImageProps } = props;
-  const theme = useAppTheme();
-
-  return (
-    <div
-      css={css`
-        width: 100%;
-        height: 100%;
-        position: relative;
-        border-radius: ${commonStyles.borderRadius[borderRadius]};
-        box-shadow: ${shadow
-          ? theme.elevation[componentElevationKey.componentOnBackground]
-              .boxShadow
-          : 'none'};
-        overflow: hidden;
-      `}
-    >
-      <div
-        css={css`
-          background-color: ${theme.colors.theme.surface.variant0};
-          top: 0;
-          right: 0;
-          bottom: 0;
-          left: 0;
-          position: absolute;
-        `}
-      >
-        <StaticImage
-          fluid={fluid}
-          css={css`
-            display: block;
-            width: 100%;
-            height: 100%;
-            transform-origin: center;
-          `}
-          imgStyle={{
-            ...imgStyle,
-            objectFit: 'cover',
-            objectPosition: 'center top',
-          }}
-          {...staticImageProps}
-        />
-      </div>
-    </div>
-  );
-};
-
-export type GridImageProps = Omit<ImageProps, 'borderRadius' | 'shadow'> & {
+export type GridImageProps = React.ComponentProps<typeof GatsbyImage> & {
   borderRadius?: BorderRadiusKey;
   shadow?: boolean;
   ratio?: number;
@@ -74,17 +16,18 @@ export type GridImageProps = Omit<ImageProps, 'borderRadius' | 'shadow'> & {
 
 export const GridImage: React.FC<GridImageProps> = props => {
   const {
-    shadow = false,
     borderRadius = 's',
+    shadow = false,
     ratio = 1,
     fixedSize = false,
     className,
-    fluid,
+    imgStyle,
+    ...gatsbyImageProps
   } = props;
 
   const theme = useAppTheme();
 
-  const containerStyles = React.useMemo(() => {
+  const wrapperStyles = React.useMemo(() => {
     const baseStyles = css`
       position: relative;
       overflow: auto;
@@ -105,7 +48,7 @@ export const GridImage: React.FC<GridImageProps> = props => {
   }, [borderRadius, fixedSize, ratio, shadow, theme.elevation]);
 
   return (
-    <div css={containerStyles} className={className}>
+    <div css={wrapperStyles} className={className}>
       <div
         css={css`
           position: absolute;
@@ -115,7 +58,45 @@ export const GridImage: React.FC<GridImageProps> = props => {
           left: 0;
         `}
       >
-        <Image fluid={fluid} shadow={shadow} borderRadius={borderRadius} />
+        <div
+          css={css`
+            width: 100%;
+            height: 100%;
+            position: relative;
+            border-radius: ${commonStyles.borderRadius[borderRadius]};
+            box-shadow: ${shadow
+              ? theme.elevation[componentElevationKey.componentOnBackground]
+                  .boxShadow
+              : 'none'};
+            overflow: hidden;
+          `}
+        >
+          <div
+            css={css`
+              background-color: ${theme.colors.theme.surface.variant0};
+              top: 0;
+              right: 0;
+              bottom: 0;
+              left: 0;
+              position: absolute;
+            `}
+          >
+            <GatsbyImage
+              css={css`
+                display: block;
+                width: 100%;
+                height: 100%;
+                transform-origin: center;
+              `}
+              imgStyle={{
+                ...imgStyle,
+                objectFit: 'cover',
+                objectPosition: 'center top',
+              }}
+              {...gatsbyImageProps}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/client/components/molecules/cards/ArtworkCard/index.tsx
+++ b/src/client/components/molecules/cards/ArtworkCard/index.tsx
@@ -15,14 +15,14 @@ import { Card, CardProps } from 'client/components/atoms/Card';
 export const ArtworkCard: React.FC<
   CardProps & {
     title: string;
-    artworkFluid: GridArtworkImageProps['fluid'];
+    image: GridArtworkImageProps;
     titleElement?: TypographyProps['element'];
     number: string;
     type: string;
   }
 > = props => {
   const {
-    artworkFluid,
+    image,
     title,
     titleElement = 'div',
     number,
@@ -32,7 +32,7 @@ export const ArtworkCard: React.FC<
   return (
     <Card {...cardProps}>
       <article>
-        <GridArtworkImage fluid={artworkFluid} alt="" />
+        <GridArtworkImage {...image} alt="" />
         <Typography
           variant="h7"
           element="div"

--- a/src/client/components/molecules/cards/HorizontalCard/index.tsx
+++ b/src/client/components/molecules/cards/HorizontalCard/index.tsx
@@ -14,10 +14,7 @@ import {
 } from 'client/components/atoms/Typography';
 
 export type HorizontalCardProps = Omit<CardProps, 'children' | 'title'> & {
-  image: {
-    fluid: GridImageProps['fluid'];
-    alt: string;
-  };
+  image: GridImageProps;
   title: {
     text: string;
     lang: string;
@@ -52,7 +49,7 @@ export const HorizontalCard: React.FC<HorizontalCardProps> = props => {
           overflow: hidden;
         `}
       >
-        <GridImage fluid={image.fluid} alt={image.alt} />
+        <GridImage {...image} />
         <div
           css={css`
             display: flex;

--- a/src/client/components/molecules/cards/MemberCard/index.tsx
+++ b/src/client/components/molecules/cards/MemberCard/index.tsx
@@ -77,7 +77,7 @@ const PositionBadge: React.FC<{
 };
 
 export type MemberCardProps = CardProps & {
-  profileImageFluid: GridMemberImageProps['fluid'];
+  profileImage: GridMemberImageProps;
   name: string;
   lang: string;
   nameElement?: TypographyProps['element'];
@@ -87,7 +87,7 @@ export type MemberCardProps = CardProps & {
 
 export const MemberCard: React.FC<MemberCardProps> = props => {
   const {
-    profileImageFluid,
+    profileImage,
     name,
     lang,
     nameElement = 'div',
@@ -111,7 +111,7 @@ export const MemberCard: React.FC<MemberCardProps> = props => {
       {...cardProps}
     >
       <article>
-        <GridMemberImage fluid={profileImageFluid} alt="" />
+        <GridMemberImage {...profileImage} alt="" />
         <Typography
           variant={textSize}
           element={nameElement}

--- a/src/client/templates/Album/index.tsx
+++ b/src/client/templates/Album/index.tsx
@@ -97,7 +97,7 @@ export const AlbumPage: React.FC<AlbumPageProps> = props => {
                 {props.centers.map(member => (
                   <li key={member.name}>
                     <MemberCard
-                      profileImageFluid={member.albumProfileImageFluid}
+                      profileImage={{ fluid: member.albumProfileImageFluid }}
                       name={formatMemberName(member.nameNotations).name}
                       lang={formatMemberName(member.nameNotations).lang}
                       to={getMemberUrl(member.name)}

--- a/src/client/templates/Album/index.tsx
+++ b/src/client/templates/Album/index.tsx
@@ -68,10 +68,7 @@ export const AlbumPage: React.FC<AlbumPageProps> = props => {
                 >
                   <HorizontalCard
                     to={getSongUrl(track.key)}
-                    image={{
-                      fluid: track.artworkFluid,
-                      alt: '',
-                    }}
+                    image={{ fluid: track.artworkFluid }}
                     title={{ text: track.title, lang: 'ja' }}
                     tags={[
                       {

--- a/src/client/templates/Discography/index.tsx
+++ b/src/client/templates/Discography/index.tsx
@@ -67,7 +67,9 @@ export const DiscographyPage: React.FC<DiscographyPageProps> = props => {
                   <li key={cd.key}>
                     <ArtworkCard
                       to={getAlbumUrl(cd.key)}
-                      artworkFluid={cd.artwork.childImageSharp.fluid}
+                      image={{
+                        fluid: cd.artwork.childImageSharp.fluid,
+                      }}
                       number={cd.number}
                       type={cd.type}
                       title={cd.title}

--- a/src/client/templates/Member/index.tsx
+++ b/src/client/templates/Member/index.tsx
@@ -504,8 +504,8 @@ export const MemberPage: React.FC<MemberPageProps> = props => {
                     shadow
                     fixedSize
                     css={css`
-                      width: ${110}px;
-                      height: ${132}px;
+                      width: 110px;
+                      height: 132px;
                       margin: ${commonStyles.spacing.xs};
                     `}
                   />

--- a/src/client/templates/Members/index.tsx
+++ b/src/client/templates/Members/index.tsx
@@ -69,7 +69,7 @@ export const MembersPage: React.FC<MembersPageProps> = props => {
                 {member.members.map(member => (
                   <li key={member.name}>
                     <MemberCard
-                      profileImageFluid={member.profileImageFluid}
+                      profileImage={{ fluid: member.profileImageFluid }}
                       name={formatMemberName(member.nameNotations).name}
                       lang={formatMemberName(member.nameNotations).lang}
                       nameElement="h3"

--- a/src/client/templates/Search/components/SearchResultCategory/index.tsx
+++ b/src/client/templates/Search/components/SearchResultCategory/index.tsx
@@ -19,7 +19,7 @@ export type SearchResultCategoryProps = {
   titleElement?: TypographyProps['element'];
   results: {
     to: string;
-    imgSharp: HorizontalCardProps['image']['fluid'];
+    image: HorizontalCardProps['image'];
     heading: HorizontalCardProps['title'];
     captions: HorizontalCardProps['tags'];
   }[];
@@ -55,7 +55,7 @@ export const SearchResultCategory: React.FC<SearchResultCategoryProps> = props =
           <li key={result.heading.text}>
             <HorizontalCard
               to={result.to}
-              image={{ fluid: result.imgSharp, alt: '' }}
+              image={result.image}
               title={result.heading}
               titleElement="h3"
               tags={result.captions}
@@ -68,7 +68,7 @@ export const SearchResultCategory: React.FC<SearchResultCategoryProps> = props =
               <li key={result.heading.text}>
                 <HorizontalCard
                   to={result.to}
-                  image={{ fluid: result.imgSharp, alt: '' }}
+                  image={result.image}
                   title={result.heading}
                   titleElement="h3"
                   tags={result.captions}

--- a/src/client/templates/Search/index.tsx
+++ b/src/client/templates/Search/index.tsx
@@ -49,7 +49,7 @@ export const SearchPage: React.FC<SearchPageProps> = props => {
 
         members.push({
           to: getMemberUrl(result.name),
-          imgSharp: result.profileImageFluid,
+          image: { fluid: result.profileImageFluid },
           heading: {
             text: memberName.name,
             lang: memberName.lang,
@@ -66,7 +66,7 @@ export const SearchPage: React.FC<SearchPageProps> = props => {
       if (result.searchType === 'albums') {
         cds.push({
           to: getAlbumUrl(result.key),
-          imgSharp: result.artworkFluid,
+          image: { fluid: result.artworkFluid },
           heading: { text: result.title, lang: 'ja' },
           captions: [
             {
@@ -98,7 +98,7 @@ export const SearchPage: React.FC<SearchPageProps> = props => {
 
         songs.push({
           to: getSongUrl(result.key),
-          imgSharp: result.artworkFluid,
+          image: { fluid: result.artworkFluid },
           heading: { text: result.title, lang: 'ja' },
           captions,
         });

--- a/src/client/templates/Song/index.tsx
+++ b/src/client/templates/Song/index.tsx
@@ -41,7 +41,7 @@ const RowContainer: React.FC = props => (
 
 type PerformerCardProps = Pick<
   MemberCardProps,
-  'profileImageFluid' | 'to' | 'position'
+  'profileImage' | 'to' | 'position'
 > & {
   nameNotations: NameNotationsForIntl;
 };
@@ -53,7 +53,7 @@ const PerformerCard: React.FC<PerformerCardProps> = props => {
     <MemberCard
       name={formatMemberName(props.nameNotations).name}
       lang={formatMemberName(props.nameNotations).lang}
-      profileImageFluid={props.profileImageFluid}
+      profileImage={props.profileImage}
       to={props.to}
       position={props.position}
       textSize="body3"
@@ -285,7 +285,9 @@ export const SongPage: React.FC<SongPageProps> = props => {
                             <li key={member.name}>
                               <PerformerCard
                                 nameNotations={member.nameNotations}
-                                profileImageFluid={member.profileImageFluid}
+                                profileImage={{
+                                  fluid: member.profileImageFluid,
+                                }}
                                 position={member.position ?? undefined}
                                 to={
                                   member.isMember

--- a/src/data/member.json
+++ b/src/data/member.json
@@ -9,7 +9,8 @@
       "lastNameEn": "akimoto",
       "firstNameEn": "manatsu"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/akimotomanatsu.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/akimotomanatsu.jpg",
       "../assets/images/members/singles/24/akimotomanatsu.jpg",
       "../assets/images/members/singles/22/akimotomanatsu.jpg",
@@ -215,7 +216,8 @@
       "lastNameEn": "ikuta",
       "firstNameEn": "erika"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/ikutaerika.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/ikutaerika.jpg",
       "../assets/images/members/singles/24/ikutaerika.jpg",
       "../assets/images/members/singles/22/ikutaerika.jpg",
@@ -423,7 +425,8 @@
       "lastNameEn": "ikoma",
       "firstNameEn": "rina"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/ikomarina_2020-08-10.jpg",
+    "gallery": [
       "../assets/images/members/others/ikomarina_2020-08-10.jpg",
       "../assets/images/members/others/ikomarina_2019-09-21.jpg",
       "../assets/images/members/singles/17/ikomarina.jpg",
@@ -621,7 +624,8 @@
       "lastNameEn": "inoue",
       "firstNameEn": "sayuri"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/inouesayuri_2020-06-11.jpg",
+    "gallery": [
       "../assets/images/members/others/inouesayuri_2020-06-11.jpg",
       "../assets/images/members/singles/25/inouesayuri.jpg",
       "../assets/images/members/singles/24/inouesayuri.jpg",
@@ -814,7 +818,8 @@
       "lastNameEn": "eto",
       "firstNameEn": "misa"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/etoumisa_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/etoumisa_2020-04-29.jpg",
       "../assets/images/members/singles/22/etoumisa.jpg",
       "../assets/images/members/singles/20/etoumisa.jpg",
@@ -1032,7 +1037,8 @@
       "lastNameEn": "kawago",
       "firstNameEn": "hina"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/kawagohina_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/kawagohina_2020-04-29.jpg",
       "../assets/images/members/singles/22/kawagohina.jpg",
       "../assets/images/members/singles/20/kawagohina.jpg",
@@ -1226,7 +1232,8 @@
       "lastNameEn": "saito",
       "firstNameEn": "asuka"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/saitouasuka.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/saitouasuka.jpg",
       "../assets/images/members/singles/24/saitouasuka.jpg",
       "../assets/images/members/singles/22/saitouasuka.jpg",
@@ -1416,7 +1423,8 @@
       "lastNameEn": "saito",
       "firstNameEn": "yuri"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/saitouyuuri_2020-09-26.jpg",
+    "gallery": [
       "../assets/images/members/others/saitouyuuri_2020-09-26.jpg",
       "../assets/images/members/others/saitouyuuri_2020-04-29.jpg",
       "../assets/images/members/singles/22/saitouyuuri.jpg",
@@ -1607,7 +1615,8 @@
       "lastNameEn": "sakurai",
       "firstNameEn": "reika"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/sakuraireika_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/sakuraireika_2020-04-29.jpg",
       "../assets/images/members/singles/22/sakuraireika.jpg",
       "../assets/images/members/singles/20/sakuraireika.jpg",
@@ -1811,7 +1820,8 @@
       "lastNameEn": "shiraishi",
       "firstNameEn": "mai"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/shiraishimai_2020-11-11.jpg",
+    "gallery": [
       "../assets/images/members/others/shiraishimai_2020-11-11.jpg",
       "../assets/images/members/singles/25/shiraishimai.jpg",
       "../assets/images/members/singles/24/shiraishimai.jpg",
@@ -2052,7 +2062,8 @@
       "lastNameEn": "takayama",
       "firstNameEn": "kazumi"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/takayamakazumi.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/takayamakazumi.jpg",
       "../assets/images/members/singles/24/takayamakazumi.jpg",
       "../assets/images/members/singles/22/takayamakazumi.jpg",
@@ -2261,7 +2272,8 @@
       "lastNameEn": "nakada",
       "firstNameEn": "kana"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/nakadakana_2020-11-11.jpg",
+    "gallery": [
       "../assets/images/members/others/nakadakana_2020-11-11.jpg",
       "../assets/images/members/singles/25/nakadakana.jpg",
       "../assets/images/members/singles/24/nakadakana.jpg",
@@ -2453,7 +2465,8 @@
       "lastNameEn": "nishino",
       "firstNameEn": "nanase"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/nishinonanase_2020-06-11.jpg",
+    "gallery": [
       "../assets/images/members/others/nishinonanase_2020-06-11.jpg",
       "../assets/images/members/others/nishinonanase_2019-09-21.jpg",
       "../assets/images/members/singles/22/nishinonanase.jpg",
@@ -2673,7 +2686,8 @@
       "lastNameEn": "nojo",
       "firstNameEn": "ami"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/noujouami_2020-09-26.jpg",
+    "gallery": [
       "../assets/images/members/others/noujouami_2020-09-26.jpg",
       "../assets/images/members/others/noujouami_2020-04-29.jpg",
       "../assets/images/members/singles/22/noujouami.jpg",
@@ -2846,7 +2860,8 @@
       "lastNameEn": "higuchi",
       "firstNameEn": "hina"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/higuchihina.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/higuchihina.jpg",
       "../assets/images/members/singles/24/higuchihina.jpg",
       "../assets/images/members/singles/22/higuchihina.jpg",
@@ -3025,7 +3040,8 @@
       "lastNameEn": "hoshino",
       "firstNameEn": "minami"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/hoshinominami.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/hoshinominami.jpg",
       "../assets/images/members/singles/24/hoshinominami.jpg",
       "../assets/images/members/singles/22/hoshinominami.jpg",
@@ -3215,7 +3231,8 @@
       "lastNameEn": "matsumura",
       "firstNameEn": "sayuri"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/matsumurasayuri.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/matsumurasayuri.jpg",
       "../assets/images/members/singles/24/matsumurasayuri.jpg",
       "../assets/images/members/singles/22/matsumurasayuri.jpg",
@@ -3413,7 +3430,8 @@
       "lastNameEn": "wakatsuki",
       "firstNameEn": "yumi"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/wakatsukiyumi_2020-06-11.jpg",
+    "gallery": [
       "../assets/images/members/others/wakatsukiyumi_2020-06-11.jpg",
       "../assets/images/members/others/wakatsukiyumi_2019-09-21.jpg",
       "../assets/images/members/singles/22/wakatsukiyumi.jpg",
@@ -3614,7 +3632,8 @@
       "lastNameEn": "wada",
       "firstNameEn": "maya"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/wadamaaya.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/wadamaaya.jpg",
       "../assets/images/members/singles/24/wadamaaya.jpg",
       "../assets/images/members/singles/22/wadamaaya.jpg",
@@ -3791,7 +3810,8 @@
       "lastNameEn": "saito",
       "firstNameEn": "chiharu"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/saitouchiharu_2020-06-11.jpg",
+    "gallery": [
       "../assets/images/members/others/saitouchiharu_2020-06-11.jpg",
       "../assets/images/members/others/saitouchiharu_2019-09-22.jpg",
       "../assets/images/members/singles/17/saitouchiharu.jpg",
@@ -3962,7 +3982,8 @@
       "lastNameEn": "kawamura",
       "firstNameEn": "mahiro"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/kawamuramahiro_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/kawamuramahiro_2020-04-29.jpg",
       "../assets/images/members/singles/17/kawamuramahiro.jpg",
       "../assets/images/members/singles/15/kawamuramahiro.jpg",
@@ -4132,7 +4153,8 @@
       "lastNameEn": "nakamoto",
       "firstNameEn": "himeka"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/nakamotohimeka_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/nakamotohimeka_2020-04-29.jpg",
       "../assets/images/members/singles/17/nakamotohimeka.jpg",
       "../assets/images/members/singles/15/nakamotohimeka.jpg",
@@ -4302,7 +4324,8 @@
       "lastNameEn": "ito",
       "firstNameEn": "marika"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/itoumarika_2020-09-26.jpg",
+    "gallery": [
       "../assets/images/members/others/itoumarika_2020-09-26.jpg",
       "../assets/images/members/others/itoumarika_2020-04-29.jpg",
       "../assets/images/members/singles/17/itoumarika.jpg",
@@ -4492,7 +4515,8 @@
       "lastNameEn": "hashimoto",
       "firstNameEn": "nanami"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/15/hashimotonanami.jpg",
+    "gallery": [
       "../assets/images/members/singles/15/hashimotonanami.jpg",
       "../assets/images/members/singles/14/hashimotonanami.jpg",
       "../assets/images/members/singles/13/hashimotonanami.jpg",
@@ -4676,7 +4700,8 @@
       "lastNameEn": "fukagawa",
       "firstNameEn": "mai"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/fukagawamai_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/fukagawamai_2020-04-29.jpg",
       "../assets/images/members/singles/14/fukagawamai.jpg",
       "../assets/images/members/singles/13/fukagawamai.jpg",
@@ -4867,7 +4892,8 @@
       "lastNameEn": "nagashima",
       "firstNameEn": "seira"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/nagashimaseira_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/nagashimaseira_2020-04-29.jpg",
       "../assets/images/members/singles/14/nagashimaseira.jpg",
       "../assets/images/members/singles/13/nagashimaseira.jpg",
@@ -5037,7 +5063,8 @@
       "lastNameEn": "matsui",
       "firstNameEn": "rena"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/matsuirena_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/matsuirena_2020-04-29.jpg",
       "../assets/images/members/singles/11/matsuirena.jpg",
       "../assets/images/members/singles/10/matsuirena.jpg",
@@ -5197,7 +5224,8 @@
       "lastNameEn": "hatanaka",
       "firstNameEn": "seira"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/hatanakaseira_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/hatanakaseira_2020-04-29.jpg",
       "../assets/images/members/singles/10/hatanakaseira.jpg",
       "../assets/images/members/singles/9/hatanakaseira.jpg",
@@ -5363,7 +5391,8 @@
       "lastNameEn": "yamato",
       "firstNameEn": "rina"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/10/yamatorina.jpg",
+    "gallery": [
       "../assets/images/members/singles/10/yamatorina.jpg",
       "../assets/images/members/singles/9/yamatorina.jpg",
       "../assets/images/members/singles/8/yamatorina.jpg",
@@ -5515,7 +5544,8 @@
       "lastNameEn": "ito",
       "firstNameEn": "nene"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/itounene_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/itounene_2020-04-29.jpg",
       "../assets/images/members/singles/9/itounene.jpg",
       "../assets/images/members/singles/8/itounene.jpg",
@@ -5676,7 +5706,8 @@
       "lastNameEn": "ichiki",
       "firstNameEn": "rena"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/ichikirena_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/ichikirena_2020-04-29.jpg",
       "../assets/images/members/singles/9/ichikirena.jpg",
       "../assets/images/members/singles/8/ichikirena.jpg",
@@ -5833,7 +5864,8 @@
       "lastNameEn": "nishikawa",
       "firstNameEn": "nanami"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/7/nishikawananami.jpg",
+    "gallery": [
       "../assets/images/members/singles/7/nishikawananami.jpg"
     ],
     "join": "second",
@@ -5976,7 +6008,8 @@
       "lastNameEn": "miyazawa",
       "firstNameEn": "seira"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/miyazawaseira_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/miyazawaseira_2020-04-29.jpg",
       "../assets/images/members/singles/6/miyazawaseira.jpg",
       "../assets/images/members/singles/5/miyazawaseira.jpg",
@@ -6138,7 +6171,8 @@
       "lastNameEn": "kashiwa",
       "firstNameEn": "yukina"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/kashiwayukina_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/kashiwayukina_2020-04-29.jpg",
       "../assets/images/members/singles/6/kashiwayukina.jpg",
       "../assets/images/members/singles/5/kashiwayukina.jpg",
@@ -6295,7 +6329,8 @@
       "lastNameEn": "ando",
       "firstNameEn": "mikumo"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/5/andoumikumo.jpg",
+    "gallery": [
       "../assets/images/members/singles/5/andoumikumo.jpg",
       "../assets/images/members/singles/4/andoumikumo.jpg",
       "../assets/images/members/singles/3/andoumikumo.jpg",
@@ -6442,7 +6477,8 @@
       "lastNameEn": "iwase",
       "firstNameEn": "yumiko"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/iwaseyumiko_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/iwaseyumiko_2020-04-29.jpg",
       "../assets/images/members/singles/3/iwaseyumiko.jpg",
       "../assets/images/members/singles/2/iwaseyumiko.jpg",
@@ -6597,7 +6633,8 @@
       "lastNameEn": "ito",
       "firstNameEn": "karin"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/itoukarin_2020-04-29.jpg",
+    "gallery": [
       "../assets/images/members/others/itoukarin_2020-04-29.jpg",
       "../assets/images/members/singles/22/itoukarin.jpg",
       "../assets/images/members/singles/20/itoukarin.jpg",
@@ -6776,7 +6813,8 @@
       "lastNameEn": "ito",
       "firstNameEn": "junna"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/itoujunna.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/itoujunna.jpg",
       "../assets/images/members/singles/24/itoujunna.jpg",
       "../assets/images/members/singles/22/itoujunna.jpg",
@@ -6951,7 +6989,8 @@
       "lastNameEn": "kitano",
       "firstNameEn": "hinako"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/kitanohinako.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/kitanohinako.jpg",
       "../assets/images/members/singles/24/kitanohinako.jpg",
       "../assets/images/members/singles/22/kitanohinako.jpg",
@@ -7135,7 +7174,8 @@
       "lastNameEn": "sasaki",
       "firstNameEn": "kotoko"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/sasakikotoko_2020-10-14.jpg",
+    "gallery": [
       "../assets/images/members/others/sasakikotoko_2020-10-14.jpg",
       "../assets/images/members/singles/25/sasakikotoko.jpg",
       "../assets/images/members/singles/24/sasakikotoko.jpg",
@@ -7307,7 +7347,8 @@
       "lastNameEn": "shinuchi",
       "firstNameEn": "mai"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/shinuchimai.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/shinuchimai.jpg",
       "../assets/images/members/singles/24/shinuchimai.jpg",
       "../assets/images/members/singles/22/shinuchimai.jpg",
@@ -7495,7 +7536,8 @@
       "lastNameEn": "suzuki",
       "firstNameEn": "ayane"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/suzukiayane.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/suzukiayane.jpg",
       "../assets/images/members/singles/24/suzukiayane.jpg",
       "../assets/images/members/singles/22/suzukiayane.jpg",
@@ -7679,7 +7721,8 @@
       "lastNameEn": "terada",
       "firstNameEn": "ranze"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/teradaranze.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/teradaranze.jpg",
       "../assets/images/members/singles/24/teradaranze.jpg",
       "../assets/images/members/singles/22/teradaranze.jpg",
@@ -7851,7 +7894,8 @@
       "lastNameEn": "hori",
       "firstNameEn": "miona"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/horimiona.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/horimiona.jpg",
       "../assets/images/members/singles/24/horimiona.jpg",
       "../assets/images/members/singles/22/horimiona.jpg",
@@ -8052,7 +8096,8 @@
       "lastNameEn": "yamazaki",
       "firstNameEn": "rena"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/yamazakirena.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/yamazakirena.jpg",
       "../assets/images/members/singles/24/yamazakirena.jpg",
       "../assets/images/members/singles/22/yamazakirena.jpg",
@@ -8225,7 +8270,8 @@
       "lastNameEn": "watanabe",
       "firstNameEn": "miria"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/watanabemiria.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/watanabemiria.jpg",
       "../assets/images/members/singles/24/watanabemiria.jpg",
       "../assets/images/members/singles/22/watanabemiria.jpg",
@@ -8396,7 +8442,8 @@
       "lastNameEn": "sagara",
       "firstNameEn": "iori"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/others/sagaraiori_2020-09-26.jpg",
+    "gallery": [
       "../assets/images/members/others/sagaraiori_2020-09-26.jpg",
       "../assets/images/members/others/sagaraiori_2020-04-29.jpg",
       "../assets/images/members/singles/17/sagaraiori.jpg",
@@ -8562,7 +8609,8 @@
       "lastNameEn": "yonetoku",
       "firstNameEn": "kyoka"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/9/yonetokukyouka.jpg",
+    "gallery": [
       "../assets/images/members/singles/9/yonetokukyouka.jpg",
       "../assets/images/members/singles/8/yonetokukyouka.jpg",
       "../assets/images/members/singles/7/yonetokukyouka.jpg"
@@ -8707,7 +8755,8 @@
       "lastNameEn": "yada",
       "firstNameEn": "risako"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/9/yadarisako.jpg",
+    "gallery": [
       "../assets/images/members/singles/9/yadarisako.jpg",
       "../assets/images/members/singles/8/yadarisako.jpg",
       "../assets/images/members/singles/7/yadarisako.jpg"
@@ -8852,7 +8901,8 @@
       "lastNameEn": "ito",
       "firstNameEn": "riria"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/itouriria.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/itouriria.jpg",
       "../assets/images/members/singles/24/itouriria.jpg",
       "../assets/images/members/singles/22/itouriria.jpg",
@@ -9008,7 +9058,8 @@
       "lastNameEn": "iwamoto",
       "firstNameEn": "renka"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/iwamotorenka.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/iwamotorenka.jpg",
       "../assets/images/members/singles/24/iwamotorenka.jpg",
       "../assets/images/members/singles/22/iwamotorenka.jpg",
@@ -9164,7 +9215,8 @@
       "lastNameEn": "umezakwa",
       "firstNameEn": "minami"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/umezawaminami.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/umezawaminami.jpg",
       "../assets/images/members/singles/24/umezawaminami.jpg",
       "../assets/images/members/singles/22/umezawaminami.jpg",
@@ -9335,7 +9387,8 @@
       "lastNameEn": "ozono",
       "firstNameEn": "momoko"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/oozonomomoko.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/oozonomomoko.jpg",
       "../assets/images/members/singles/24/oozonomomoko.jpg",
       "../assets/images/members/singles/22/oozonomomoko.jpg",
@@ -9497,7 +9550,8 @@
       "lastNameEn": "kubo",
       "firstNameEn": "shiori"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/kuboshiori.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/kuboshiori.jpg",
       "../assets/images/members/singles/24/kuboshiori.jpg",
       "../assets/images/members/singles/22/kuboshiori.jpg",
@@ -9655,7 +9709,8 @@
       "lastNameEn": "sakaguchi",
       "firstNameEn": "tamami"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/sakaguchitamami.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/sakaguchitamami.jpg",
       "../assets/images/members/singles/24/sakaguchitamami.jpg",
       "../assets/images/members/singles/22/sakaguchitamami.jpg",
@@ -9813,7 +9868,8 @@
       "lastNameEn": "sato",
       "firstNameEn": "kaede"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/satoukaede.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/satoukaede.jpg",
       "../assets/images/members/singles/24/satoukaede.jpg",
       "../assets/images/members/singles/22/satoukaede.jpg",
@@ -9969,7 +10025,8 @@
       "lastNameEn": "nakamura",
       "firstNameEn": "reno"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/nakamurareno.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/nakamurareno.jpg",
       "../assets/images/members/singles/24/nakamurareno.jpg",
       "../assets/images/members/singles/22/nakamurareno.jpg",
@@ -10125,7 +10182,8 @@
       "lastNameEn": "mukai",
       "firstNameEn": "hazuki"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/mukaihazuki.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/mukaihazuki.jpg",
       "../assets/images/members/singles/24/mukaihazuki.jpg",
       "../assets/images/members/singles/22/mukaihazuki.jpg",
@@ -10281,7 +10339,8 @@
       "lastNameEn": "yamashita",
       "firstNameEn": "mizuki"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/yamashitamizuki.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/yamashitamizuki.jpg",
       "../assets/images/members/singles/24/yamashitamizuki.jpg",
       "../assets/images/members/singles/22/yamashitamizuki.jpg",
@@ -10454,7 +10513,8 @@
       "lastNameEn": "yoshida",
       "firstNameEn": "ayanochristie"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/yoshidaayanochristie.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/yoshidaayanochristie.jpg",
       "../assets/images/members/singles/24/yoshidaayanochristie.jpg",
       "../assets/images/members/singles/22/yoshidaayanochristie.jpg",
@@ -10610,7 +10670,8 @@
       "lastNameEn": "yoda",
       "firstNameEn": "yuki"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/yodayuuki.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/yodayuuki.jpg",
       "../assets/images/members/singles/24/yodayuuki.jpg",
       "../assets/images/members/singles/22/yodayuuki.jpg",
@@ -10797,7 +10858,8 @@
       "lastNameEn": "endo",
       "firstNameEn": "sakura"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/endousakura.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/endousakura.jpg",
       "../assets/images/members/singles/24/endousakura.jpg",
       "../assets/images/members/singles/22/endousakura.jpg"
@@ -10951,7 +11013,8 @@
       "lastNameEn": "kaki",
       "firstNameEn": "haruka"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/kakiharuka.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/kakiharuka.jpg",
       "../assets/images/members/singles/24/kakiharuka.jpg",
       "../assets/images/members/singles/22/kakiharuka.jpg"
@@ -11105,7 +11168,8 @@
       "lastNameEn": "kakehashi",
       "firstNameEn": "sayaka"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/kakehashisayaka.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/kakehashisayaka.jpg",
       "../assets/images/members/singles/24/kakehashisayaka.jpg",
       "../assets/images/members/singles/22/kakehashisayaka.jpg"
@@ -11259,7 +11323,8 @@
       "lastNameEn": "kanagawa",
       "firstNameEn": "saya"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/kanagawasaya.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/kanagawasaya.jpg",
       "../assets/images/members/singles/24/kanagawasaya.jpg",
       "../assets/images/members/singles/22/kanagawasaya.jpg"
@@ -11413,7 +11478,8 @@
       "lastNameEn": "kitagawa",
       "firstNameEn": "yuri"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/kitagawayuri.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/kitagawayuri.jpg",
       "../assets/images/members/singles/24/kitagawayuri.jpg",
       "../assets/images/members/singles/22/kitagawayuri.jpg"
@@ -11567,7 +11633,8 @@
       "lastNameEn": "shibata",
       "firstNameEn": "yuna"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/shibatayuna.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/shibatayuna.jpg",
       "../assets/images/members/singles/24/shibatayuna.jpg",
       "../assets/images/members/singles/22/shibatayuna.jpg"
@@ -11721,7 +11788,8 @@
       "lastNameEn": "seimiya",
       "firstNameEn": "rei"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/seimiyarei.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/seimiyarei.jpg",
       "../assets/images/members/singles/24/seimiyarei.jpg",
       "../assets/images/members/singles/22/seimiyarei.jpg"
@@ -11875,7 +11943,8 @@
       "lastNameEn": "tamura",
       "firstNameEn": "mayu"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/tamuramayu.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/tamuramayu.jpg",
       "../assets/images/members/singles/24/tamuramayu.jpg",
       "../assets/images/members/singles/22/tamuramayu.jpg"
@@ -12029,7 +12098,8 @@
       "lastNameEn": "tsutsui",
       "firstNameEn": "ayame"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/tsutsuiayame.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/tsutsuiayame.jpg",
       "../assets/images/members/singles/24/tsutsuiayame.jpg",
       "../assets/images/members/singles/22/tsutsuiayame.jpg"
@@ -12183,7 +12253,8 @@
       "lastNameEn": "hayakawa",
       "firstNameEn": "seira"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/hayakawaseira.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/hayakawaseira.jpg",
       "../assets/images/members/singles/24/hayakawaseira.jpg",
       "../assets/images/members/singles/22/hayakawaseira.jpg"
@@ -12337,7 +12408,8 @@
       "lastNameEn": "yakubo",
       "firstNameEn": "mio"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/yakubomio.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/yakubomio.jpg",
       "../assets/images/members/singles/24/yakubomio.jpg",
       "../assets/images/members/singles/22/yakubomio.jpg"
@@ -12491,7 +12563,8 @@
       "lastNameEn": "kuromi",
       "firstNameEn": "haruka"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/kuromiharuka.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/kuromiharuka.jpg",
       "../assets/images/members/others/kuromiharuka_2020-02-18.jpg",
       "../assets/images/members/others/kuromiharuka_2020-02-16.jpg"
@@ -12649,7 +12722,8 @@
       "lastNameEn": "satou",
       "firstNameEn": "rika"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/satourika.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/satourika.jpg",
       "../assets/images/members/others/satourika_2020-02-18.jpg",
       "../assets/images/members/others/satourika_2020-02-16.jpg"
@@ -12807,7 +12881,8 @@
       "lastNameEn": "hayashi",
       "firstNameEn": "runa"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/hayashiruna.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/hayashiruna.jpg",
       "../assets/images/members/others/hayashiruna_2020-02-18.jpg",
       "../assets/images/members/others/hayashiruna_2020-02-16.jpg"
@@ -12965,7 +13040,8 @@
       "lastNameEn": "matsuo",
       "firstNameEn": "miyu"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/matsuomiyu.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/matsuomiyu.jpg",
       "../assets/images/members/others/matsuomiyu_2020-02-16.jpg"
     ],
@@ -13122,7 +13198,8 @@
       "lastNameEn": "yumiki",
       "firstNameEn": "nao"
     },
-    "profileImages": [
+    "profileImage": "../assets/images/members/singles/25/yumikinao.jpg",
+    "gallery": [
       "../assets/images/members/singles/25/yumikinao.jpg",
       "../assets/images/members/others/yumikinao_2020-02-18.jpg",
       "../assets/images/members/others/yumikinao_2020-02-16.jpg"

--- a/src/pages/discography/index.tsx
+++ b/src/pages/discography/index.tsx
@@ -17,7 +17,7 @@ export const query = graphql`
         number
         artwork {
           childImageSharp {
-            fluid {
+            fluid(maxWidth: 200) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }

--- a/src/pages/discography/index.tsx
+++ b/src/pages/discography/index.tsx
@@ -17,7 +17,7 @@ export const query = graphql`
         number
         artwork {
           childImageSharp {
-            fluid(maxWidth: 200) {
+            fluid(maxWidth: 300) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }

--- a/src/pages/discography/{AlbumJson.key}.tsx
+++ b/src/pages/discography/{AlbumJson.key}.tsx
@@ -14,7 +14,7 @@ export const query = graphql`
       artworks {
         url {
           childImageSharp {
-            fluid {
+            fluid(maxWidth: 160) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }
@@ -38,7 +38,7 @@ export const query = graphql`
         }
         albumProfileImage {
           childImageSharp {
-            fluid {
+            fluid(maxWidth: 130) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }

--- a/src/pages/discography/{AlbumJson.key}.tsx
+++ b/src/pages/discography/{AlbumJson.key}.tsx
@@ -14,7 +14,7 @@ export const query = graphql`
       artworks {
         url {
           childImageSharp {
-            fluid(maxWidth: 160) {
+            fluid(maxWidth: 240) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }
@@ -38,7 +38,7 @@ export const query = graphql`
         }
         albumProfileImage {
           childImageSharp {
-            fluid(maxWidth: 130) {
+            fluid(maxWidth: 200) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -54,8 +54,8 @@ const HomePage: React.FC = () => {
     query {
       file(relativePath: { eq: "design/preview.jpg" }) {
         childImageSharp {
-          fixed(width: 800, height: 400) {
-            ...GatsbyImageSharpFixed_withWebp
+          fluid(maxWidth: 1200) {
+            ...GatsbyImageSharpFluid_withWebp
           }
         }
       }
@@ -73,10 +73,12 @@ const HomePage: React.FC = () => {
         `}
       >
         <GatsbyImage
-          fixed={heroImageData.file.childImageSharp.fixed}
+          fluid={heroImageData.file.childImageSharp.fluid}
           alt="NOGILIB"
           css={css`
             max-width: 80vw;
+            width: 800px;
+            height: 400px;
             border-radius: ${commonStyles.borderRadius.m};
             box-shadow: ${commonStyles.elevations[3].boxShadow};
           `}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,7 @@ import { Card } from 'client/components/atoms/Card';
 import { DiscographyIcon } from 'client/components/atoms/icons/DiscographyIcon';
 import { MembersIcon } from 'client/components/atoms/icons/MembersIcon';
 import { SearchIcon } from 'client/components/atoms/icons/SearchIcon';
-import { StaticImage } from 'client/components/atoms/images/StaticImage';
+import { GatsbyImage } from 'client/components/atoms/images/GatsbyImage';
 
 const SubHeading: React.FC = props => (
   <Typography
@@ -72,7 +72,7 @@ const HomePage: React.FC = () => {
           margin-top: ${commonStyles.spacing.l};
         `}
       >
-        <StaticImage
+        <GatsbyImage
           fixed={heroImageData.file.childImageSharp.fixed}
           alt="NOGILIB"
           css={css`

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -26,7 +26,7 @@ export const query = graphql`
         }
         profileImage {
           childImageSharp {
-            fluid(maxWidth: 130) {
+            fluid(maxWidth: 200) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -26,7 +26,7 @@ export const query = graphql`
         }
         profileImage {
           childImageSharp {
-            fluid {
+            fluid(maxWidth: 130) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }

--- a/src/pages/members/{MemberJson.name}.tsx
+++ b/src/pages/members/{MemberJson.name}.tsx
@@ -17,14 +17,14 @@ export const query = graphql`
       }
       profileImage {
         childImageSharp {
-          fluid(maxWidth: 200) {
+          fluid(maxWidth: 300) {
             ...GatsbyImageSharpFluid_withWebp
           }
         }
       }
       gallery {
         childImageSharp {
-          fluid(maxWidth: 110) {
+          fluid(maxWidth: 165) {
             ...GatsbyImageSharpFluid_withWebp
           }
         }
@@ -50,7 +50,7 @@ export const query = graphql`
       photoAlbums {
         cover {
           childImageSharp {
-            fluid(maxWidth: 180) {
+            fluid(maxWidth: 270) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }

--- a/src/pages/members/{MemberJson.name}.tsx
+++ b/src/pages/members/{MemberJson.name}.tsx
@@ -17,14 +17,14 @@ export const query = graphql`
       }
       profileImage {
         childImageSharp {
-          fluid {
+          fluid(maxWidth: 200) {
             ...GatsbyImageSharpFluid_withWebp
           }
         }
       }
       gallery {
         childImageSharp {
-          fluid {
+          fluid(maxWidth: 110) {
             ...GatsbyImageSharpFluid_withWebp
           }
         }
@@ -50,7 +50,7 @@ export const query = graphql`
       photoAlbums {
         cover {
           childImageSharp {
-            fluid {
+            fluid(maxWidth: 180) {
               ...GatsbyImageSharpFluid_withWebp
             }
           }

--- a/src/pages/members/{MemberJson.name}.tsx
+++ b/src/pages/members/{MemberJson.name}.tsx
@@ -15,7 +15,14 @@ export const query = graphql`
         lastNameEn
         lastNameFurigana
       }
-      profileImages {
+      profileImage {
+        childImageSharp {
+          fluid {
+            ...GatsbyImageSharpFluid_withWebp
+          }
+        }
+      }
+      gallery {
         childImageSharp {
           fluid {
             ...GatsbyImageSharpFluid_withWebp
@@ -72,7 +79,12 @@ export const query = graphql`
 
 type MemberPageDataNode = {
   nameNotations: MemberPageData['nameNotations'];
-  profileImages: {
+  profileImage: {
+    childImageSharp: {
+      fluid: FluidObject;
+    };
+  };
+  gallery: {
     childImageSharp: {
       fluid: FluidObject;
     };
@@ -102,7 +114,7 @@ type MemberPageDataNode = {
 
 export type MemberPageProps = Omit<
   MemberPageDataNode,
-  'profileImages' | 'photoAlbums'
+  'gallery' | 'profileImage' | 'photoAlbums'
 > & {
   profileImageFluid: FluidObject;
   galleryFluids: FluidObject[];
@@ -148,14 +160,14 @@ const MemberPageContainer: React.FC<{
   );
 
   const gallery = React.useMemo(() => {
-    return memberData.profileImages.map(photo => photo.childImageSharp.fluid);
-  }, [memberData.profileImages]);
+    return memberData.gallery.map(photo => photo.childImageSharp.fluid);
+  }, [memberData.gallery]);
 
   return memberData ? (
     <MemberPage
       nameNotations={memberData.nameNotations}
+      profileImageFluid={memberData.profileImage.childImageSharp.fluid}
       galleryFluids={gallery}
-      profileImageFluid={gallery[0]}
       glowStickColor={memberData.glowStickColor}
       sites={memberData.sites}
       join={memberData.join}

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -19,7 +19,7 @@ export const query = graphql`
           albumType
           artwork {
             childImageSharp {
-              fluid(maxWidth: 90) {
+              fluid(maxWidth: 135) {
                 ...GatsbyImageSharpFluid_withWebp
               }
             }
@@ -42,7 +42,7 @@ export const query = graphql`
           }
           artwork {
             childImageSharp {
-              fluid(maxWidth: 90) {
+              fluid(maxWidth: 135) {
                 ...GatsbyImageSharpFluid_withWebp
               }
             }
@@ -64,7 +64,7 @@ export const query = graphql`
           join
           profileImage {
             childImageSharp {
-              fluid(maxWidth: 90) {
+              fluid(maxWidth: 135) {
                 ...GatsbyImageSharpFluid_withWebp
               }
             }

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -19,7 +19,7 @@ export const query = graphql`
           albumType
           artwork {
             childImageSharp {
-              fluid {
+              fluid(maxWidth: 90) {
                 ...GatsbyImageSharpFluid_withWebp
               }
             }
@@ -42,7 +42,7 @@ export const query = graphql`
           }
           artwork {
             childImageSharp {
-              fluid {
+              fluid(maxWidth: 90) {
                 ...GatsbyImageSharpFluid_withWebp
               }
             }
@@ -64,7 +64,7 @@ export const query = graphql`
           join
           profileImage {
             childImageSharp {
-              fluid {
+              fluid(maxWidth: 90) {
                 ...GatsbyImageSharpFluid_withWebp
               }
             }

--- a/src/pages/songs/{SongJson.key}.tsx
+++ b/src/pages/songs/{SongJson.key}.tsx
@@ -11,7 +11,7 @@ export const query = graphql`
       type
       artwork {
         childImageSharp {
-          fluid {
+          fluid(maxWidth: 200) {
             src
           }
         }
@@ -48,7 +48,7 @@ export const query = graphql`
         }
         profileImage {
           childImageSharp {
-            fluid {
+            fluid(maxWidth: 110) {
               src
             }
           }

--- a/src/pages/songs/{SongJson.key}.tsx
+++ b/src/pages/songs/{SongJson.key}.tsx
@@ -11,7 +11,7 @@ export const query = graphql`
       type
       artwork {
         childImageSharp {
-          fluid(maxWidth: 200) {
+          fluid(maxWidth: 300) {
             src
           }
         }
@@ -48,7 +48,7 @@ export const query = graphql`
         }
         profileImage {
           childImageSharp {
-            fluid(maxWidth: 110) {
+            fluid(maxWidth: 165) {
               src
             }
           }

--- a/src/server/pages/member.ts
+++ b/src/server/pages/member.ts
@@ -5,7 +5,8 @@ import { sortByDate } from 'utils/sorting';
 export type MemberPageData = {
   name: MemberResult['name'];
   nameNotations: MemberResult['nameNotations'];
-  profileImages: MemberResult['profileImages']['gallery'];
+  profileImage: MemberResult['profileImages']['gallery'][0];
+  gallery: MemberResult['profileImages']['gallery'];
   join: MemberResult['join'];
   graduation: MemberResult['graduation'];
   birthday: MemberResult['birthday'];
@@ -29,7 +30,8 @@ export function getMemberPageData(members: Members): MemberPageData[] {
   return members.result.map(member => ({
     name: member.name,
     nameNotations: member.nameNotations,
-    profileImages: member.profileImages.gallery,
+    profileImage: member.profileImages.gallery[0],
+    gallery: member.profileImages.gallery,
     join: member.join,
     graduation: member.graduation,
     birthday: member.birthday,


### PR DESCRIPTION
## Changes

- Adding `maxWidth` to image query to make sure we ship the images in a proper size
- Refactor `GatsbyImage` component to make it capable to take all props

## Image Transfer Before And After

Tested on the album page (`/discography/influencer/`)

| DPR  | Before | After |
| ---- | ---- | --- |
| 1 | 126 kB | 50.7 kB |
| 2 | 126 kB | 127 kB |
| 3 | 126 kB | 127 kB |
