### PR TITLE
Keep left and right safe areas

### DIFF
--- a/src/client/components/layout/Page/components/BottomNavigationBar/index.tsx
+++ b/src/client/components/layout/Page/components/BottomNavigationBar/index.tsx
@@ -84,7 +84,10 @@ export const BottomNavigationBar: React.FC = () => {
             align-items: center;
             justify-content: space-between;
             min-height: ${commonStyles.sizes.navigationBarHeight};
-            padding: 0 0.5em env(safe-area-inset-bottom);
+            padding-top: 0;
+            padding-bottom: env(safe-area-inset-bottom);
+            padding-left: calc(0.5em + env(safe-area-inset-left));
+            padding-right: calc(0.5em + env(safe-area-inset-right));
 
             & > * {
               flex: 1;

--- a/src/client/components/layout/Page/components/TopNavigationBar/index.tsx
+++ b/src/client/components/layout/Page/components/TopNavigationBar/index.tsx
@@ -92,9 +92,10 @@ const SelectionItem = React.forwardRef<SelectionItemRef, SelectionItemProps>(
 
 const Settings: React.FC = () => {
   const [isDropdownOpen, toggleDropdown] = React.useState(false);
-  const hideDropdown = React.useCallback(() => toggleDropdown(false), [
-    toggleDropdown,
-  ]);
+  const hideDropdown = React.useCallback(
+    () => toggleDropdown(false),
+    [toggleDropdown]
+  );
   const switchDropdown = React.useCallback(
     () => toggleDropdown(!isDropdownOpen),
     [isDropdownOpen, toggleDropdown]
@@ -289,7 +290,14 @@ export const TopNavigationBar: React.FC = () => {
           max-width: ${commonStyles.breakPoints.maxContent};
           height: 100%;
           margin: auto;
-          padding: 0 ${commonStyles.spacing.l};
+          padding-top: 0;
+          padding-bottom: 0;
+          padding-left: calc(
+            ${commonStyles.spacing.l} + env(safe-area-inset-left)
+          );
+          padding-right: calc(
+            ${commonStyles.spacing.l} + env(safe-area-inset-right)
+          );
           display: flex;
           justify-content: space-between;
           align-items: center;

--- a/src/client/components/layout/Page/index.tsx
+++ b/src/client/components/layout/Page/index.tsx
@@ -20,7 +20,7 @@ const SkipLink: React.FC = () => {
       css={css`
         display: inline-block;
         top: ${commonStyles.spacing.xs};
-        left: ${commonStyles.spacing.s};
+        left: calc(${commonStyles.spacing.s} + env(safe-area-inset-left));
         transform: translateY(-170%);
         opacity: 0;
         transition: all 0.3s;

--- a/src/client/components/layout/PageContent.tsx
+++ b/src/client/components/layout/PageContent.tsx
@@ -103,8 +103,12 @@ export const PageContent: React.FC<HeaderProps> = props => {
           ${commonStyles.sizes.navigationBarHeight} + ${commonStyles.spacing.m} +
             env(safe-area-inset-top)
         );
-        padding-left: ${commonStyles.spacing.m};
-        padding-right: ${commonStyles.spacing.m};
+        padding-left: calc(
+          ${commonStyles.spacing.m} + env(safe-area-inset-left)
+        );
+        padding-right: calc(
+          ${commonStyles.spacing.m} + env(safe-area-inset-right)
+        );
         padding-bottom: calc(
           ${commonStyles.sizes.navigationBarHeight} +
             ${commonStyles.spacing.xxl} + env(safe-area-inset-bottom)


### PR DESCRIPTION
## Changes

- Add left and right safe areas to each page to make sure content is not hidden in horizontal mode

| Before | After |
| :---: | :---: |
| ![image](https://user-images.githubusercontent.com/23146992/123129368-dfc70380-d486-11eb-85c3-2f53ba7f6327.png) | ![image](https://user-images.githubusercontent.com/23146992/123129542-fbcaa500-d486-11eb-9ec4-dd67ccbbf06b.png) |
