### PR TITLE
fix: show single profile images for songs in that single

### DIFF
--- a/src/data/song.json
+++ b/src/data/song.json
@@ -21696,9 +21696,9 @@
             "firstNameEn": "rina"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/ikomarina@1x.jpg",
-            "md": "/images/members/singles/12/ikomarina@2x.jpg",
-            "lg": "/images/members/singles/12/ikomarina@3x.jpg"
+            "sm": "/images/members/singles/13/ikomarina@1x.jpg",
+            "md": "/images/members/singles/13/ikomarina@2x.jpg",
+            "lg": "/images/members/singles/13/ikomarina@3x.jpg"
           },
           "position": "center",
           "isMember": true
@@ -21714,9 +21714,9 @@
             "firstNameEn": "manatsu"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/akimotomanatsu@1x.jpg",
-            "md": "/images/members/singles/12/akimotomanatsu@2x.jpg",
-            "lg": "/images/members/singles/12/akimotomanatsu@3x.jpg"
+            "sm": "/images/members/singles/13/akimotomanatsu@1x.jpg",
+            "md": "/images/members/singles/13/akimotomanatsu@2x.jpg",
+            "lg": "/images/members/singles/13/akimotomanatsu@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21732,9 +21732,9 @@
             "firstNameEn": "erika"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/ikutaerika@1x.jpg",
-            "md": "/images/members/singles/12/ikutaerika@2x.jpg",
-            "lg": "/images/members/singles/12/ikutaerika@3x.jpg"
+            "sm": "/images/members/singles/13/ikutaerika@1x.jpg",
+            "md": "/images/members/singles/13/ikutaerika@2x.jpg",
+            "lg": "/images/members/singles/13/ikutaerika@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21750,9 +21750,9 @@
             "firstNameEn": "marika"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/itoumarika@1x.jpg",
-            "md": "/images/members/singles/12/itoumarika@2x.jpg",
-            "lg": "/images/members/singles/12/itoumarika@3x.jpg"
+            "sm": "/images/members/singles/13/itoumarika@1x.jpg",
+            "md": "/images/members/singles/13/itoumarika@2x.jpg",
+            "lg": "/images/members/singles/13/itoumarika@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21768,9 +21768,9 @@
             "firstNameEn": "sayuri"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/inouesayuri@1x.jpg",
-            "md": "/images/members/singles/12/inouesayuri@2x.jpg",
-            "lg": "/images/members/singles/12/inouesayuri@3x.jpg"
+            "sm": "/images/members/singles/13/inouesayuri@1x.jpg",
+            "md": "/images/members/singles/13/inouesayuri@2x.jpg",
+            "lg": "/images/members/singles/13/inouesayuri@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21786,9 +21786,9 @@
             "firstNameEn": "misa"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/etoumisa@1x.jpg",
-            "md": "/images/members/singles/12/etoumisa@2x.jpg",
-            "lg": "/images/members/singles/12/etoumisa@3x.jpg"
+            "sm": "/images/members/singles/13/etoumisa@1x.jpg",
+            "md": "/images/members/singles/13/etoumisa@2x.jpg",
+            "lg": "/images/members/singles/13/etoumisa@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21804,9 +21804,9 @@
             "firstNameEn": "asuka"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/saitouasuka@1x.jpg",
-            "md": "/images/members/singles/12/saitouasuka@2x.jpg",
-            "lg": "/images/members/singles/12/saitouasuka@3x.jpg"
+            "sm": "/images/members/singles/13/saitouasuka@1x.jpg",
+            "md": "/images/members/singles/13/saitouasuka@2x.jpg",
+            "lg": "/images/members/singles/13/saitouasuka@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21822,9 +21822,9 @@
             "firstNameEn": "yuri"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/saitouyuuri@1x.jpg",
-            "md": "/images/members/singles/12/saitouyuuri@2x.jpg",
-            "lg": "/images/members/singles/12/saitouyuuri@3x.jpg"
+            "sm": "/images/members/singles/13/saitouyuuri@1x.jpg",
+            "md": "/images/members/singles/13/saitouyuuri@2x.jpg",
+            "lg": "/images/members/singles/13/saitouyuuri@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21840,9 +21840,9 @@
             "firstNameEn": "reika"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/sakuraireika@1x.jpg",
-            "md": "/images/members/singles/12/sakuraireika@2x.jpg",
-            "lg": "/images/members/singles/12/sakuraireika@3x.jpg"
+            "sm": "/images/members/singles/13/sakuraireika@1x.jpg",
+            "md": "/images/members/singles/13/sakuraireika@2x.jpg",
+            "lg": "/images/members/singles/13/sakuraireika@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21858,9 +21858,9 @@
             "firstNameEn": "mai"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/shiraishimai@1x.jpg",
-            "md": "/images/members/singles/12/shiraishimai@2x.jpg",
-            "lg": "/images/members/singles/12/shiraishimai@3x.jpg"
+            "sm": "/images/members/singles/13/shiraishimai@1x.jpg",
+            "md": "/images/members/singles/13/shiraishimai@2x.jpg",
+            "lg": "/images/members/singles/13/shiraishimai@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21876,9 +21876,9 @@
             "firstNameEn": "mai"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/shinuchimai@1x.jpg",
-            "md": "/images/members/singles/12/shinuchimai@2x.jpg",
-            "lg": "/images/members/singles/12/shinuchimai@3x.jpg"
+            "sm": "/images/members/singles/13/shinuchimai@1x.jpg",
+            "md": "/images/members/singles/13/shinuchimai@2x.jpg",
+            "lg": "/images/members/singles/13/shinuchimai@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21894,9 +21894,9 @@
             "firstNameEn": "kazumi"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/takayamakazumi@1x.jpg",
-            "md": "/images/members/singles/12/takayamakazumi@2x.jpg",
-            "lg": "/images/members/singles/12/takayamakazumi@3x.jpg"
+            "sm": "/images/members/singles/13/takayamakazumi@1x.jpg",
+            "md": "/images/members/singles/13/takayamakazumi@2x.jpg",
+            "lg": "/images/members/singles/13/takayamakazumi@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21912,9 +21912,9 @@
             "firstNameEn": "nanase"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/nishinonanase@1x.jpg",
-            "md": "/images/members/singles/12/nishinonanase@2x.jpg",
-            "lg": "/images/members/singles/12/nishinonanase@3x.jpg"
+            "sm": "/images/members/singles/13/nishinonanase@1x.jpg",
+            "md": "/images/members/singles/13/nishinonanase@2x.jpg",
+            "lg": "/images/members/singles/13/nishinonanase@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21930,9 +21930,9 @@
             "firstNameEn": "nanami"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/hashimotonanami@1x.jpg",
-            "md": "/images/members/singles/12/hashimotonanami@2x.jpg",
-            "lg": "/images/members/singles/12/hashimotonanami@3x.jpg"
+            "sm": "/images/members/singles/13/hashimotonanami@1x.jpg",
+            "md": "/images/members/singles/13/hashimotonanami@2x.jpg",
+            "lg": "/images/members/singles/13/hashimotonanami@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21948,9 +21948,9 @@
             "firstNameEn": "mai"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/fukagawamai@1x.jpg",
-            "md": "/images/members/singles/12/fukagawamai@2x.jpg",
-            "lg": "/images/members/singles/12/fukagawamai@3x.jpg"
+            "sm": "/images/members/singles/13/fukagawamai@1x.jpg",
+            "md": "/images/members/singles/13/fukagawamai@2x.jpg",
+            "lg": "/images/members/singles/13/fukagawamai@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21966,9 +21966,9 @@
             "firstNameEn": "minami"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/hoshinominami@1x.jpg",
-            "md": "/images/members/singles/12/hoshinominami@2x.jpg",
-            "lg": "/images/members/singles/12/hoshinominami@3x.jpg"
+            "sm": "/images/members/singles/13/hoshinominami@1x.jpg",
+            "md": "/images/members/singles/13/hoshinominami@2x.jpg",
+            "lg": "/images/members/singles/13/hoshinominami@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -21984,9 +21984,9 @@
             "firstNameEn": "sayuri"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/matsumurasayuri@1x.jpg",
-            "md": "/images/members/singles/12/matsumurasayuri@2x.jpg",
-            "lg": "/images/members/singles/12/matsumurasayuri@3x.jpg"
+            "sm": "/images/members/singles/13/matsumurasayuri@1x.jpg",
+            "md": "/images/members/singles/13/matsumurasayuri@2x.jpg",
+            "lg": "/images/members/singles/13/matsumurasayuri@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -22002,9 +22002,9 @@
             "firstNameEn": "yumi"
           },
           "profileImage": {
-            "sm": "/images/members/singles/12/wakatsukiyumi@1x.jpg",
-            "md": "/images/members/singles/12/wakatsukiyumi@2x.jpg",
-            "lg": "/images/members/singles/12/wakatsukiyumi@3x.jpg"
+            "sm": "/images/members/singles/13/wakatsukiyumi@1x.jpg",
+            "md": "/images/members/singles/13/wakatsukiyumi@2x.jpg",
+            "lg": "/images/members/singles/13/wakatsukiyumi@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44359,9 +44359,9 @@
             "firstNameEn": "minami"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/hoshinominami@1x.jpg",
-            "md": "/images/members/singles/26/hoshinominami@2x.jpg",
-            "lg": "/images/members/singles/26/hoshinominami@3x.jpg"
+            "sm": "/images/members/singles/27/hoshinominami@1x.jpg",
+            "md": "/images/members/singles/27/hoshinominami@2x.jpg",
+            "lg": "/images/members/singles/27/hoshinominami@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44377,9 +44377,9 @@
             "firstNameEn": "yuki"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/yodayuuki@1x.jpg",
-            "md": "/images/members/singles/26/yodayuuki@2x.jpg",
-            "lg": "/images/members/singles/26/yodayuuki@3x.jpg"
+            "sm": "/images/members/singles/27/yodayuuki@1x.jpg",
+            "md": "/images/members/singles/27/yodayuuki@2x.jpg",
+            "lg": "/images/members/singles/27/yodayuuki@3x.jpg"
           },
           "position": "center",
           "isMember": true
@@ -44395,9 +44395,9 @@
             "firstNameEn": "ayame"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/tsutsuiayame@1x.jpg",
-            "md": "/images/members/singles/26/tsutsuiayame@2x.jpg",
-            "lg": "/images/members/singles/26/tsutsuiayame@3x.jpg"
+            "sm": "/images/members/singles/27/tsutsuiayame@1x.jpg",
+            "md": "/images/members/singles/27/tsutsuiayame@2x.jpg",
+            "lg": "/images/members/singles/27/tsutsuiayame@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44415,9 +44415,9 @@
             "firstNameEn": "manatsu"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/akimotomanatsu@1x.jpg",
-            "md": "/images/members/singles/26/akimotomanatsu@2x.jpg",
-            "lg": "/images/members/singles/26/akimotomanatsu@3x.jpg"
+            "sm": "/images/members/singles/27/akimotomanatsu@1x.jpg",
+            "md": "/images/members/singles/27/akimotomanatsu@2x.jpg",
+            "lg": "/images/members/singles/27/akimotomanatsu@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44433,9 +44433,9 @@
             "firstNameEn": "erika"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/ikutaerika@1x.jpg",
-            "md": "/images/members/singles/26/ikutaerika@2x.jpg",
-            "lg": "/images/members/singles/26/ikutaerika@3x.jpg"
+            "sm": "/images/members/singles/27/ikutaerika@1x.jpg",
+            "md": "/images/members/singles/27/ikutaerika@2x.jpg",
+            "lg": "/images/members/singles/27/ikutaerika@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44451,9 +44451,9 @@
             "firstNameEn": "minami"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/umezawaminami@1x.jpg",
-            "md": "/images/members/singles/26/umezawaminami@2x.jpg",
-            "lg": "/images/members/singles/26/umezawaminami@3x.jpg"
+            "sm": "/images/members/singles/27/umezawaminami@1x.jpg",
+            "md": "/images/members/singles/27/umezawaminami@2x.jpg",
+            "lg": "/images/members/singles/27/umezawaminami@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44469,9 +44469,9 @@
             "firstNameEn": "mizuki"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/yamashitamizuki@1x.jpg",
-            "md": "/images/members/singles/26/yamashitamizuki@2x.jpg",
-            "lg": "/images/members/singles/26/yamashitamizuki@3x.jpg"
+            "sm": "/images/members/singles/27/yamashitamizuki@1x.jpg",
+            "md": "/images/members/singles/27/yamashitamizuki@2x.jpg",
+            "lg": "/images/members/singles/27/yamashitamizuki@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44487,9 +44487,9 @@
             "firstNameEn": "shiori"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/kuboshiori@1x.jpg",
-            "md": "/images/members/singles/26/kuboshiori@2x.jpg",
-            "lg": "/images/members/singles/26/kuboshiori@3x.jpg"
+            "sm": "/images/members/singles/27/kuboshiori@1x.jpg",
+            "md": "/images/members/singles/27/kuboshiori@2x.jpg",
+            "lg": "/images/members/singles/27/kuboshiori@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44505,9 +44505,9 @@
             "firstNameEn": "asuka"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/saitouasuka@1x.jpg",
-            "md": "/images/members/singles/26/saitouasuka@2x.jpg",
-            "lg": "/images/members/singles/26/saitouasuka@3x.jpg"
+            "sm": "/images/members/singles/27/saitouasuka@1x.jpg",
+            "md": "/images/members/singles/27/saitouasuka@2x.jpg",
+            "lg": "/images/members/singles/27/saitouasuka@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44523,9 +44523,9 @@
             "firstNameEn": "sayuri"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/matsumurasayuri@1x.jpg",
-            "md": "/images/members/singles/26/matsumurasayuri@2x.jpg",
-            "lg": "/images/members/singles/26/matsumurasayuri@3x.jpg"
+            "sm": "/images/members/singles/27/matsumurasayuri@1x.jpg",
+            "md": "/images/members/singles/27/matsumurasayuri@2x.jpg",
+            "lg": "/images/members/singles/27/matsumurasayuri@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44543,9 +44543,9 @@
             "firstNameEn": "haruka"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/kakiharuka@1x.jpg",
-            "md": "/images/members/singles/26/kakiharuka@2x.jpg",
-            "lg": "/images/members/singles/26/kakiharuka@3x.jpg"
+            "sm": "/images/members/singles/27/kakiharuka@1x.jpg",
+            "md": "/images/members/singles/27/kakiharuka@2x.jpg",
+            "lg": "/images/members/singles/27/kakiharuka@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44561,9 +44561,9 @@
             "firstNameEn": "renka"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/iwamotorenka@1x.jpg",
-            "md": "/images/members/singles/26/iwamotorenka@2x.jpg",
-            "lg": "/images/members/singles/26/iwamotorenka@3x.jpg"
+            "sm": "/images/members/singles/27/iwamotorenka@1x.jpg",
+            "md": "/images/members/singles/27/iwamotorenka@2x.jpg",
+            "lg": "/images/members/singles/27/iwamotorenka@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44579,9 +44579,9 @@
             "firstNameEn": "rei"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/seimiyarei@1x.jpg",
-            "md": "/images/members/singles/26/seimiyarei@2x.jpg",
-            "lg": "/images/members/singles/26/seimiyarei@3x.jpg"
+            "sm": "/images/members/singles/27/seimiyarei@1x.jpg",
+            "md": "/images/members/singles/27/seimiyarei@2x.jpg",
+            "lg": "/images/members/singles/27/seimiyarei@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44597,9 +44597,9 @@
             "firstNameEn": "momoko"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/oozonomomoko@1x.jpg",
-            "md": "/images/members/singles/26/oozonomomoko@2x.jpg",
-            "lg": "/images/members/singles/26/oozonomomoko@3x.jpg"
+            "sm": "/images/members/singles/27/oozonomomoko@1x.jpg",
+            "md": "/images/members/singles/27/oozonomomoko@2x.jpg",
+            "lg": "/images/members/singles/27/oozonomomoko@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44615,9 +44615,9 @@
             "firstNameEn": "sakura"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/endousakura@1x.jpg",
-            "md": "/images/members/singles/26/endousakura@2x.jpg",
-            "lg": "/images/members/singles/26/endousakura@3x.jpg"
+            "sm": "/images/members/singles/27/endousakura@1x.jpg",
+            "md": "/images/members/singles/27/endousakura@2x.jpg",
+            "lg": "/images/members/singles/27/endousakura@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44633,9 +44633,9 @@
             "firstNameEn": "kazumi"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/takayamakazumi@1x.jpg",
-            "md": "/images/members/singles/26/takayamakazumi@2x.jpg",
-            "lg": "/images/members/singles/26/takayamakazumi@3x.jpg"
+            "sm": "/images/members/singles/27/takayamakazumi@1x.jpg",
+            "md": "/images/members/singles/27/takayamakazumi@2x.jpg",
+            "lg": "/images/members/singles/27/takayamakazumi@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44651,9 +44651,9 @@
             "firstNameEn": "mai"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/shinuchimai@1x.jpg",
-            "md": "/images/members/singles/26/shinuchimai@2x.jpg",
-            "lg": "/images/members/singles/26/shinuchimai@3x.jpg"
+            "sm": "/images/members/singles/27/shinuchimai@1x.jpg",
+            "md": "/images/members/singles/27/shinuchimai@2x.jpg",
+            "lg": "/images/members/singles/27/shinuchimai@3x.jpg"
           },
           "position": null,
           "isMember": true
@@ -44669,9 +44669,9 @@
             "firstNameEn": "mayu"
           },
           "profileImage": {
-            "sm": "/images/members/singles/26/tamuramayu@1x.jpg",
-            "md": "/images/members/singles/26/tamuramayu@2x.jpg",
-            "lg": "/images/members/singles/26/tamuramayu@3x.jpg"
+            "sm": "/images/members/singles/27/tamuramayu@1x.jpg",
+            "md": "/images/members/singles/27/tamuramayu@2x.jpg",
+            "lg": "/images/members/singles/27/tamuramayu@3x.jpg"
           },
           "position": null,
           "isMember": true

--- a/src/server/pages/song.ts
+++ b/src/server/pages/song.ts
@@ -50,10 +50,17 @@ function getPerformerProfileImage(
   song: SongResult,
   member: MemberResult
 ): ImageUrl {
-  const { album } = song.performersTag;
   const { profileImages } = member;
+  const { album } = song.performersTag;
+  const { single } = song;
 
   const singleProfileImages = arrayToObject(profileImages.singles, 'number');
+
+  // If the song is in a single, use the single's profile image.
+  if (singleProfileImages[single.number]) {
+    return singleProfileImages[single.number].url;
+  }
+
   const digitalProfileImages = arrayToObject(profileImages.digital, 'number');
   const albumProfileImages = arrayToObject(profileImages.albums, 'number');
 


### PR DESCRIPTION
## Changes

- For songs in a single, use the single's profile images for each member. This will fix the profile images for *全部 夢のまま* and *悲しみの忘れ方*

Comparision for *全部 夢のまま*

| Before | After |
|:---:|:---:|
| ![nogilib com_songs_zenbuyumenomama](https://user-images.githubusercontent.com/23146992/126199670-64e371c5-1786-4d57-9326-27a16e03bb54.png) | ![localhost_8080_songs_zenbuyumenomama](https://user-images.githubusercontent.com/23146992/126199682-6c3ed11e-5812-4b59-a311-277792dbba3d.png) |
