### PR TITLE
Fix typo on "no results" translation

### DIFF
--- a/src/client/i18n/translations.ts
+++ b/src/client/i18n/translations.ts
@@ -501,7 +501,7 @@ const dictionary = {
   },
   'no result': {
     en: 'no result',
-    ja: '結果がみ見つかりませんでした',
+    ja: '結果が見つかりませんでした',
     zh: '找不到搜索结果',
   },
   'A web app for showing the information about Nogizaka46 in a user-friendly way':


### PR DESCRIPTION
There's a typo on the search result page that showing below:

![B302B6B3-A4AB-43A8-9817-C196C76D9E48](https://user-images.githubusercontent.com/14477793/139575125-2774d6ac-edef-4a55-a001-171678c643b4.png)

This pull request will change the text to "結果が見つかりませんでした".