### PR TITLE
Extend formation component width

### DIFF
--- a/src/pages/songs/[id].tsx
+++ b/src/pages/songs/[id].tsx
@@ -294,12 +294,13 @@ export const SongPage: React.FC<SongPageProps> = props => {
                             justify-content: center;
                             margin-top: 0.5em;
                             width: 100vw;
+                            max-width: 1920px;
                             box-sizing: border-box;
                             overflow-x: hidden;
                             position: relative;
                             /* CSS hack to make child component larger than the parent's width */
                             /* @see https://stackoverflow.com/a/24895631 */
-                            left: calc(-50vw + 50%);
+                            left: calc(50% - min(100vw, 1920px) / 2);
                             padding-left: calc(
                               ${commonStyles.spacing.m} +
                                 env(safe-area-inset-left)

--- a/src/pages/songs/[id].tsx
+++ b/src/pages/songs/[id].tsx
@@ -286,12 +286,28 @@ export const SongPage: React.FC<SongPageProps> = props => {
                             {formatNth({ num: index + 1, unit: 'row' })}
                           </SectionSubtitle>
                         )}
+
                         <ul
                           css={css`
                             display: flex;
                             flex-wrap: wrap;
                             justify-content: center;
                             margin-top: 0.5em;
+                            width: 100vw;
+                            box-sizing: border-box;
+                            overflow-x: hidden;
+                            position: relative;
+                            /* CSS hack to make child component larger than the parent's width */
+                            /* @see https://stackoverflow.com/a/24895631 */
+                            left: calc(-50vw + 50%);
+                            padding-left: calc(
+                              ${commonStyles.spacing.m} +
+                                env(safe-area-inset-left)
+                            );
+                            padding-right: calc(
+                              ${commonStyles.spacing.m} +
+                                env(safe-area-inset-right)
+                            );
                           `}
                         >
                           {row.map(member => (


### PR DESCRIPTION
## Changes

- Extend the formation component's width to prevent each formation row from wrapping to the next line


| Before | After |
| :---:  | :---: |
| ![screencapture-nogilib-en-songs-kiminishikarareta-2021-11-18-00_17_28](https://user-images.githubusercontent.com/23146992/142229346-37a65117-b076-4c53-8fe9-7bba72182288.png) | ![screencapture-localhost-8080-en-songs-kiminishikarareta-2021-11-18-00_17_55](https://user-images.githubusercontent.com/23146992/142229392-61d0ea19-c1f2-44f7-a151-e346b11c5f33.png) |