### PR TITLE
Prevent layout shifts when changing language

### DIFF
--- a/src/client/components/atoms/Typography/index.tsx
+++ b/src/client/components/atoms/Typography/index.tsx
@@ -95,6 +95,7 @@ export const Typography: React.FC<TypographyProps> = props => {
       css`
         color: var(${getColorVarName(textColor.on, textColor.variant)});
         font-weight: ${bold ? 700 : undefined};
+        line-height: 1.5;
         font-family: ${fontFamilyValue};
         text-transform: ${capitalize ? 'capitalize' : 'initial'};
       `,


### PR DESCRIPTION
## Changes

- Add `line-height` to make sure text in different languages share the same height. This will prevent layout shifts when changing language.
