### PR TITLE
Fix setting dropdown auto focus

### DIFF
--- a/src/client/components/layout/Page/components/SettingsMenu/index.tsx
+++ b/src/client/components/layout/Page/components/SettingsMenu/index.tsx
@@ -204,12 +204,6 @@ export const SettingsMenu: React.FC = () => {
   );
 
   React.useEffect(() => {
-    if (!isDropdownOpen) {
-      settingsButtonRef.current?.focus();
-    }
-  }, [isDropdownOpen]);
-
-  React.useEffect(() => {
     // Trap focus when the dropdown is open
     const handleWindowKeyDown = (event: KeyboardEvent) => {
       if (isDropdownOpen) {


### PR DESCRIPTION
## Changes

- Prevent the setting dropdown from getting auto-focus on mount time or during mouse navigation
