### PR TITLE
Replace React with Preact to reduce JS bundle size

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,4 +16,17 @@ module.exports = {
       },
     ];
   },
+  webpack: (config, { dev, isServer }) => {
+    // Swap React with Preact in the client production build
+    // @see https://youtu.be/R59e1Vl5lO8?t=177
+    if (!dev && !isServer) {
+      Object.assign(config.resolve.alias, {
+        react: 'preact/compat',
+        'react-dom/test-utils': 'preact/test-utils',
+        'react-dom': 'preact/compat',
+      });
+    }
+
+    return config;
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15895,6 +15895,11 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "preact": {
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
+      "integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "focus-visible": "^5.2.0",
     "framer-motion": "^5.3.3",
     "next": "^12.0.4",
+    "preact": "^10.6.4",
     "react": "^17.0.0",
     "react-dom": "^17.0.2",
     "react-lazyload": "^3.2.0"


### PR DESCRIPTION
## Changes

- Swap React with Preact in the client production build

### JS bundle size comparison

| Before | After |
| :---: | :---: |
|  ![Screen Shot 2021-12-28 at 19 19 10](https://user-images.githubusercontent.com/23146992/147556490-a81bc606-e3ad-466e-8f32-e461e3a1d333.jpg) | ![Screen Shot 2021-12-28 at 19 18 52](https://user-images.githubusercontent.com/23146992/147556501-6892acdc-7905-4cd3-9aa4-326171322464.jpg) |
